### PR TITLE
fix: update text and icon colors to default theme

### DIFF
--- a/src/components/home/PropertyList.tsx
+++ b/src/components/home/PropertyList.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import { MOCK_DATA_PROPERTY_LIST } from '@/mockData/tableData';
 import { Property } from '@/@types/property';
 
-
 const properties = [
   {
     image: '/img/house1.jpg',
@@ -140,6 +139,7 @@ const properties = [
     baths: 2,
     petFriendly: false,
   },
+];
 
 const sortByPrice = (propertyA: Property, propertyB: Property) => {
   return parseInt(propertyA.price) - parseInt(propertyB.price);
@@ -166,7 +166,6 @@ const sortList: sortListInterface[] = [
   { id: 2, name: 'propertyList.sortBy.orderTwo', sortFn: sortByPrice },
   { id: 3, name: 'propertyList.sortBy.orderThree', sortFn: sortByPriceReverse },
   { id: 4, name: 'propertyList.sortBy.orderFour', sortFn: undefined },
-
 ];
 
 const PropertyList: React.FC = () => {
@@ -216,7 +215,7 @@ const PropertyList: React.FC = () => {
           >
             <BsSortDownAlt className="text-lg mr-2 dark:text-gray-200" />
             {t('propertyList.sortBy.title')}{' '}
-            <span className="text-default-color cursor-pointer hover:underline ml-1 text-orange-500">
+            <span className="text-default-color cursor-pointer hover:underline ml-1">
               {t(sortOption.name)}
             </span>
           </button>

--- a/src/components/profile/pages/ApartmentsComponent.tsx
+++ b/src/components/profile/pages/ApartmentsComponent.tsx
@@ -378,7 +378,7 @@ const ApartmentsComponent = () => {
                 </td>
                 <td className="p-2 h-[70px] flex justify-center items-center">
                   {apartment.promoted && (
-                    <HiOutlineFire size={30} color="#FF7F00" />
+                    <HiOutlineFire size={30} className="text-default-color" />
                   )}
                 </td>
                 <td className="p-2 text-custom-grey dark:text-gray-400">
@@ -386,7 +386,7 @@ const ApartmentsComponent = () => {
                 </td>
                 <td className="p-2 flex justify-center">
                   <button>
-                  <FaEllipsisH className="text-default-color w-[1.3rem] h-[1.3rem]" />
+                    <FaEllipsisH className="text-default-color w-[1.3rem] h-[1.3rem]" />
                   </button>
                 </td>
               </tr>

--- a/src/components/profile/pages/ApartmentsComponent.tsx
+++ b/src/components/profile/pages/ApartmentsComponent.tsx
@@ -203,7 +203,7 @@ const ApartmentsComponent = () => {
             </span>
             <div
               className={`w-[20px] h-[20px] rounded flex items-center justify-center ${
-                isPromotedFilterActive ? 'bg-[#FF7F00]' : 'bg-gray-300'
+                isPromotedFilterActive ? `bg-default-color` : 'bg-gray-300'
               }`}
             >
               {isPromotedFilterActive && <BsCheck className="text-white" />}


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

This pull request updates the text and icon colours on the Home page (/) and Profile Apartments page (/profile/my-apartments) to align with the design scheme specified in tailwind.config.ts. It addresses issue #148 

## 🌀 Summary of Changes

1. **Home Page (/)**:  Updated the "Relevance" text color in the sorting option to use the text-default-color class.

 2.  **Profile Apartments Page (/profile/my-apartments)**: Updated the "Promoted" icons to use the text-default-color class.

## 🛠 Testing

### Evidence Before Solution

Before the Fix/Feature

- Description: On the Home page, the "Relevance" text in the sorting option used an incorrect red color. On the Profile Apartments page, the "Promoted" icons used an orange color that did not match the design scheme.
![image](https://github.com/user-attachments/assets/42e271f0-7500-43c3-815c-bd75b54b83db)
![image](https://github.com/user-attachments/assets/c69ea8e8-0feb-4614-b460-f3ab999f1803)



### Evidence After Solution

- Description: The "Relevance" text and "Promoted" icons now use the text-default-color class, ensuring consistency with the design scheme.
![image](https://github.com/user-attachments/assets/0e664373-cf04-4d13-b026-686f63742173)
![image](https://github.com/user-attachments/assets/974d31c7-86bb-4d0b-83e8-a89acee73a46)


## 📂 Related Issue

This pull request will close #148.

---

🎉 Thank you for reviewing this PR! 🎉
