### PR TITLE
feat: implement navigation for the room page

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -19178,8 +19178,6 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -87,5 +87,6 @@
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.3.2",
     "typescript": "5.8.2"
-  }
+  },
+  "packageManager": "yarn@4.9.4+sha512.7b1cb0b62abba6a537b3a2ce00811a843bea02bcf53138581a6ae5b1bf563f734872bd47de49ce32a9ca9dcaff995aa789577ffb16811da7c603dcf69e73750b"
 }

--- a/src/app/room/page.tsx
+++ b/src/app/room/page.tsx
@@ -3,16 +3,25 @@
 import RoomPhotos from "@/components/rooms/RoomPhotos";
 import RoomDetails from "@/components/rooms/RoomDetails";
 import AditionalRoomPhotos from "@/components/rooms/AditionalRoomPhotos";
+import { NavigationHeader } from "@/components/navigation/NavigationHeader";
 
 const additionalImages = [
   "/img/room1.png?height=195&width=300",
   "/img/room1.png?height=195&width=300",
   "/img/room1.png?height=195&width=300",
 ]
+const breadcrumbs = [
+  { label: "Search", href: "/dashboard/search" },
+  { label: "Shikara Hotel", isCurrentPage: true },
+];
 
 export default function RoomPage() {
   return (
-    <div className="container mx-auto py-8 max-w-6xl">
+    <div className="container mx-auto pb-8 max-w-6xl">
+      <NavigationHeader
+        breadcrumbs={breadcrumbs}
+        backButtonFallback="/search"
+      />
       <h1 className="text-2xl font-bold mb-6">Room Gallery</h1>
       <div className="grid grid-cols-1 md:grid-cols-12 gap-2">
         {/* Main Room Photos - Takes 8 columns on desktop */}

--- a/src/components/navigation/BackButton.tsx
+++ b/src/components/navigation/BackButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+interface BackButtonProps {
+  fallbackTo?: string;
+  className?: string;
+}
+
+export const BackButton = ({ fallbackTo = "/", className = "" }: BackButtonProps) => {
+  const router = useRouter();
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(fallbackTo);
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleBack}
+      className={`h-9 px-2 hover:bg-muted/50 ${className}`}
+    >
+      <ArrowLeft className="h-4 w-4 mr-2" />
+      Back
+    </Button>
+  );
+};

--- a/src/components/navigation/Breadcrumbs.tsx
+++ b/src/components/navigation/Breadcrumbs.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ChevronRight, Home } from "lucide-react";
+import Link from "next/link";
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+  isCurrentPage?: boolean;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+export const Breadcrumbs = ({ items, className = "" }: BreadcrumbsProps) => {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={`flex items-center space-x-1 text-sm ${className}`}
+    >
+      <Link
+        href="/"
+        className="flex items-center text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <Home className="h-4 w-4" />
+      </Link>
+
+      {items.map((item, index) => (
+        <div key={index} className="flex items-center space-x-1">
+          <ChevronRight className="h-4 w-4 text-breadcrumb-separator" />
+          {item.href && !item.isCurrentPage ? (
+            <Link
+              href={item.href}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {item.label}
+            </Link>
+          ) : (
+            <span
+              className={
+                item.isCurrentPage
+                  ? "text-foreground font-medium"
+                  : "text-muted-foreground"
+              }
+            >
+              {item.label}
+            </span>
+          )}
+        </div>
+      ))}
+    </nav>
+  );
+};

--- a/src/components/navigation/NavigationHeader.tsx
+++ b/src/components/navigation/NavigationHeader.tsx
@@ -1,0 +1,33 @@
+import { BackButton } from "./BackButton";
+import { Breadcrumbs } from "./Breadcrumbs";
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+  isCurrentPage?: boolean;
+}
+
+interface NavigationHeaderProps {
+  breadcrumbs: BreadcrumbItem[];
+  backButtonFallback?: string;
+  className?: string;
+}
+
+export const NavigationHeader = ({ 
+  breadcrumbs, 
+  backButtonFallback, 
+  className = "" 
+}: NavigationHeaderProps) => {
+  return (
+    <div className={` border-b  ${className}`}>
+      <div className="container mx-auto px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-4">
+            <BackButton fallbackTo={backButtonFallback} />
+            <Breadcrumbs items={breadcrumbs} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #208
Add `NavigationHeader` with BackButton and Breadcrumbs for RoomPage  

## Description  
This PR introduces a reusable **NavigationHeader** component that combines a back button and breadcrumb navigation for better page context and navigation across the app.  

### BackButton  
- Uses  `useRouter` to handle navigation.  
- Navigates back in history if available, otherwise falls back to a provided route.  

### Breadcrumbs  
- Built with  `Link` for navigation.  
- Supports active state styling for the current page.  
- Displays a home icon and dynamically renders breadcrumb items.  

### NavigationHeader  
- Composes BackButton and Breadcrumbs into a consistent header UI.  
- Accepts `breadcrumbs` and `backButtonFallback` as props.  

### Integration in RoomPage  
- Added `NavigationHeader` with breadcrumb items for the “Shikara Hotel” example.  
- Provides a fallback route for the back button (`/search`).  

## Screenshots  
<img width="2870" height="1794" alt="image" src="https://github.com/user-attachments/assets/e5b46a23-b5c3-4601-be33-746192ea6b7d" />


## Notes  
This structure is reusable across multiple pages, ensuring consistent navigation UX.  
