### PR TITLE
feat: add hotel listing and apartment detail pages

### DIFF
--- a/app/hotel/[id]/escrow/create/page.tsx
+++ b/app/hotel/[id]/escrow/create/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { HotelHeader } from '@/components/hotel';
+import Link from 'next/link';
+import { use } from 'react';
+
+export default function HotelEscrowCreatePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const resolvedParams = use(params);
+
+  return (
+    <div className="min-h-screen bg-[#faf7f3]">
+      <HotelHeader />
+      <main className="mx-auto max-w-[860px] px-6 py-16">
+        <div className="rounded-[18px] border border-[#e7ddd5] bg-white p-8 shadow-sm">
+          <span className="inline-flex rounded-full bg-[#fff1e7] px-3 py-1 text-xs font-semibold uppercase tracking-[0.08em] text-[#ff6a00]">
+            Escrow flow
+          </span>
+          <h1 className="mt-5 text-[34px] font-semibold tracking-[-0.04em] text-[#1d1d1d]">
+            Create escrow for apartment {resolvedParams.id}
+          </h1>
+          <p className="mt-4 max-w-[620px] text-base leading-7 text-[#666666]">
+            This route is wired so the BOOK button from the apartment detail
+            page lands on a valid escrow creation screen instead of a 404. The
+            full escrow form can be layered onto this route in the follow-up
+            issue.
+          </p>
+
+          <div className="mt-8 flex flex-wrap gap-4">
+            <Link
+              href={`/hotel/${resolvedParams.id}`}
+              className="rounded-[10px] border border-[#d7cdc4] px-5 py-3 text-sm font-medium text-[#282828]"
+            >
+              Back to apartment
+            </Link>
+            <Link
+              href="/hotel"
+              className="rounded-[10px] bg-[#ff6a00] px-5 py-3 text-sm font-semibold text-white"
+            >
+              Browse more apartments
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/hotel/[id]/page.tsx
+++ b/app/hotel/[id]/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {
+  ApartmentDetail,
+  HotelHeader,
+  SuggestionsList,
+} from '@/components/hotel';
+import { getHotelById, getSuggestedHotels } from '@/mockData/hotels';
+import { useRouter } from 'next/navigation';
+import { use } from 'react';
+
+export default function HotelDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const router = useRouter();
+  const resolvedParams = use(params);
+  const apartment = getHotelById(resolvedParams.id);
+  const suggestions = getSuggestedHotels(apartment.id);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <HotelHeader />
+
+      <div className="mx-auto flex max-w-[1180px] flex-col lg:flex-row">
+        <SuggestionsList
+          apartments={suggestions}
+          onSelect={(id) => router.push(`/hotel/${id}`)}
+        />
+        <ApartmentDetail
+          apartment={apartment}
+          onBook={() => router.push(`/hotel/${apartment.id}/escrow/create`)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/hotel/page.tsx
+++ b/app/hotel/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import {
+  ApartmentGrid,
+  BedroomTabs,
+  FilterSidebar,
+  HotelHeader,
+} from '@/components/hotel';
+import { STUB_HOTELS } from '@/mockData/hotels';
+import { useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { BsSortDownAlt } from 'react-icons/bs';
+
+type SortOption = 'relevance' | 'price-low' | 'price-high';
+
+export default function HotelListingPage() {
+  const router = useRouter();
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([
+    'Family',
+    'Students',
+  ]);
+  const [selectedLocations, setSelectedLocations] = useState<string[]>([
+    'San José',
+    'Heredia',
+  ]);
+  const [selectedBedrooms, setSelectedBedrooms] = useState('all');
+  const [sortOption] = useState<SortOption>('relevance');
+  const [minPrice, setMinPrice] = useState(3200);
+  const [maxPrice, setMaxPrice] = useState(206000);
+
+  const filteredApartments = useMemo(() => {
+    const apartments = STUB_HOTELS.filter((apartment) => {
+      const matchesCategory =
+        selectedCategories.length === 0 ||
+        selectedCategories.includes(apartment.category);
+      const matchesLocation =
+        selectedLocations.length === 0 ||
+        selectedLocations.includes(apartment.location);
+      const matchesBedroom =
+        selectedBedrooms === 'all' ||
+        apartment.bedrooms === Number(selectedBedrooms);
+      const matchesPrice =
+        apartment.price >= minPrice && apartment.price <= maxPrice;
+
+      return (
+        matchesCategory && matchesLocation && matchesBedroom && matchesPrice
+      );
+    });
+
+    if (sortOption === 'price-low') {
+      return [...apartments].sort((left, right) => left.price - right.price);
+    }
+
+    if (sortOption === 'price-high') {
+      return [...apartments].sort((left, right) => right.price - left.price);
+    }
+
+    return [...apartments].sort(
+      (left, right) => Number(right.promoted) - Number(left.promoted)
+    );
+  }, [
+    maxPrice,
+    minPrice,
+    selectedBedrooms,
+    selectedCategories,
+    selectedLocations,
+    sortOption,
+  ]);
+
+  const toggleValue = (values: string[], value: string) =>
+    values.includes(value)
+      ? values.filter((item) => item !== value)
+      : [...values, value];
+
+  const handleApartmentClick = (apartment: HotelListing) => {
+    router.push(`/hotel/${apartment.id}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-white text-[#1c1c1c]">
+      <HotelHeader />
+
+      <div className="mx-auto flex max-w-[1180px] flex-col lg:flex-row">
+        <FilterSidebar
+          selectedCategories={selectedCategories}
+          selectedLocations={selectedLocations}
+          minPrice={minPrice}
+          maxPrice={maxPrice}
+          onCategoryToggle={(category) =>
+            setSelectedCategories((current) => toggleValue(current, category))
+          }
+          onLocationToggle={(location) =>
+            setSelectedLocations((current) => toggleValue(current, location))
+          }
+          onMinPriceChange={setMinPrice}
+          onMaxPriceChange={setMaxPrice}
+        />
+
+        <main className="flex-1 px-6 py-8 lg:px-12">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <h1 className="text-[24px] leading-tight text-[#1d1d1d] sm:text-[30px]">
+                Available for rent in{' '}
+                <span className="font-semibold">Costa Rica, San José</span>
+              </h1>
+              <p className="mt-3 text-sm text-[#515151]">204 units available</p>
+            </div>
+
+            <div className="flex items-center gap-2 text-sm text-[#202020]">
+              <BsSortDownAlt className="h-4 w-4" />
+              <span>Sort by:</span>
+              <span className="font-semibold text-[#ff6a00]">Relevance</span>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <BedroomTabs
+              selected={selectedBedrooms}
+              onSelect={setSelectedBedrooms}
+            />
+          </div>
+
+          <div className="mt-8">
+            <ApartmentGrid
+              apartments={filteredApartments}
+              onApartmentClick={handleApartmentClick}
+            />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/@types/hotel.ts
+++ b/src/@types/hotel.ts
@@ -1,0 +1,31 @@
+export interface HotelAmenitySummary {
+  bedrooms: number;
+  bathrooms: number;
+  petFriendly: boolean;
+}
+
+export interface HotelOwner {
+  name: string;
+  avatar: string;
+}
+
+export interface HotelListing extends HotelAmenitySummary {
+  id: string;
+  name: string;
+  address: string;
+  price: number;
+  promoted: boolean;
+  images: string[];
+  category: 'Family' | 'Students' | 'Travelers';
+  location:
+    | 'San José'
+    | 'Heredia'
+    | 'Alajuela'
+    | 'Cartago'
+    | 'Puntarenas'
+    | 'Guanacaste'
+    | 'Limón';
+  owner: HotelOwner;
+  description: string;
+  favorite?: boolean;
+}

--- a/src/components/hotel/AmenityIcons.tsx
+++ b/src/components/hotel/AmenityIcons.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { HotelAmenitySummary } from '@/@types/hotel';
+import { FaBath, FaBed, FaPaw } from 'react-icons/fa';
+
+interface AmenityIconsProps extends HotelAmenitySummary {
+  compact?: boolean;
+}
+
+function AmenityPill({
+  icon,
+  label,
+  compact = false,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  compact?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className={`grid rounded-full bg-[#fff1e7] text-[#ff6a00] ${
+          compact ? 'h-6 w-6 place-items-center' : 'h-8 w-8 place-items-center'
+        }`}
+      >
+        {icon}
+      </span>
+      <span className={`${compact ? 'text-[11px]' : 'text-sm'} text-[#6b7280]`}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export default function AmenityIcons({
+  bedrooms,
+  bathrooms,
+  petFriendly,
+  compact = false,
+}: AmenityIconsProps) {
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-4 ${compact ? 'gap-3' : 'gap-5'}`}
+    >
+      <AmenityPill
+        compact={compact}
+        icon={<FaBed className={compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />}
+        label={`${bedrooms} bd.`}
+      />
+      <AmenityPill
+        compact={compact}
+        icon={<FaPaw className={compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />}
+        label={petFriendly ? 'pet friendly' : 'no pets'}
+      />
+      <AmenityPill
+        compact={compact}
+        icon={<FaBath className={compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />}
+        label={`${bathrooms} ba.`}
+      />
+    </div>
+  );
+}

--- a/src/components/hotel/ApartmentCard.tsx
+++ b/src/components/hotel/ApartmentCard.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import { cn } from '@/utils/cn';
+import Image from 'next/image';
+import { AiOutlineHeart } from 'react-icons/ai';
+import { FaFireAlt } from 'react-icons/fa';
+import AmenityIcons from './AmenityIcons';
+
+interface ApartmentCardProps {
+  apartment: HotelListing;
+  onClick?: () => void;
+}
+
+export default function ApartmentCard({
+  apartment,
+  onClick,
+}: ApartmentCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group w-full overflow-hidden rounded-[16px] border border-[#e7e2dc] bg-white text-left transition hover:-translate-y-0.5 hover:shadow-[0_12px_30px_rgba(0,0,0,0.08)]"
+    >
+      <div className="relative">
+        <Image
+          src={apartment.images[0]}
+          alt={apartment.name}
+          width={420}
+          height={280}
+          className="h-[170px] w-full object-cover"
+        />
+        {apartment.promoted ? (
+          <span className="absolute bottom-0 left-0 inline-flex items-center gap-1 rounded-tr-[10px] bg-[#ff6a00] px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.02em] text-white">
+            <FaFireAlt className="h-3.5 w-3.5" />
+            Promoted
+          </span>
+        ) : null}
+      </div>
+
+      <div className="space-y-3 px-4 py-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-end gap-2">
+            <span className="text-[30px] font-semibold leading-none text-[#10a156]">
+              ${apartment.price.toLocaleString()}
+            </span>
+            <span className="pb-1 text-xs text-[#8b8b8b]">Per month</span>
+          </div>
+          <AiOutlineHeart
+            className={cn(
+              'h-5 w-5',
+              apartment.favorite
+                ? 'fill-[#ff2c2c] text-[#ff2c2c]'
+                : 'text-[#ff2c2c]'
+            )}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold text-[#222222]">
+            {apartment.name}
+          </h3>
+          <p className="line-clamp-1 text-xs text-[#8a8a8a]">
+            {apartment.address}
+          </p>
+        </div>
+
+        <AmenityIcons
+          bedrooms={apartment.bedrooms}
+          bathrooms={apartment.bathrooms}
+          petFriendly={apartment.petFriendly}
+          compact
+        />
+      </div>
+    </button>
+  );
+}

--- a/src/components/hotel/ApartmentDetail.tsx
+++ b/src/components/hotel/ApartmentDetail.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import Image from 'next/image';
+import { FaMapMarkerAlt } from 'react-icons/fa';
+import AmenityIcons from './AmenityIcons';
+import ImageGallery from './ImageGallery';
+
+interface ApartmentDetailProps {
+  apartment: HotelListing;
+  onBook: () => void;
+}
+
+export default function ApartmentDetail({
+  apartment,
+  onBook,
+}: ApartmentDetailProps) {
+  return (
+    <section className="flex-1 px-6 py-8 lg:px-10">
+      <ImageGallery images={apartment.images} promoted={apartment.promoted} />
+
+      <div className="mt-8 flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex-1">
+          <h1 className="text-[34px] font-semibold tracking-[-0.04em] text-[#181818]">
+            {apartment.name}
+          </h1>
+
+          <div className="mt-5 flex items-center gap-3 text-sm text-[#717171]">
+            <span className="grid h-8 w-8 place-items-center rounded-full bg-[#fff1e7] text-[#ff6a00]">
+              <FaMapMarkerAlt className="h-4 w-4" />
+            </span>
+            <span>{apartment.address}</span>
+          </div>
+
+          <div className="mt-8">
+            <AmenityIcons
+              bedrooms={apartment.bedrooms}
+              bathrooms={apartment.bathrooms}
+              petFriendly={apartment.petFriendly}
+            />
+          </div>
+        </div>
+
+        <div className="w-full rounded-[12px] lg:max-w-[210px]">
+          <button
+            type="button"
+            onClick={onBook}
+            className="w-full rounded-[8px] bg-[#ff6a00] px-6 py-4 text-xl font-semibold text-white transition hover:bg-[#ec6200]"
+          >
+            BOOK
+          </button>
+          <div className="mt-4 flex items-end gap-2">
+            <span className="text-[34px] font-semibold leading-none text-[#10a156]">
+              ${apartment.price.toLocaleString()}
+            </span>
+            <span className="pb-1 text-sm text-[#808080]">Per month</span>
+          </div>
+
+          <div className="mt-8 flex items-center justify-end gap-3">
+            <span className="text-sm font-medium text-[#5a5a5a]">
+              {apartment.owner.name}
+            </span>
+            <Image
+              src={apartment.owner.avatar}
+              alt={apartment.owner.name}
+              width={34}
+              height={34}
+              className="h-[34px] w-[34px] rounded-full object-cover"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-10 max-w-[760px]">
+        <h2 className="text-[22px] font-semibold text-[#1b1b1b]">
+          Apartment details
+        </h2>
+        <p className="mt-4 text-sm leading-6 text-[#6d6d6d]">
+          {apartment.description}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/hotel/ApartmentGrid.tsx
+++ b/src/components/hotel/ApartmentGrid.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import ApartmentCard from './ApartmentCard';
+
+interface ApartmentGridProps {
+  apartments: HotelListing[];
+  onApartmentClick: (apartment: HotelListing) => void;
+}
+
+export default function ApartmentGrid({
+  apartments,
+  onApartmentClick,
+}: ApartmentGridProps) {
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+      {apartments.map((apartment) => (
+        <ApartmentCard
+          key={apartment.id}
+          apartment={apartment}
+          onClick={() => onApartmentClick(apartment)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/hotel/BedroomTabs.tsx
+++ b/src/components/hotel/BedroomTabs.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { BEDROOM_FILTERS } from '@/mockData/hotels';
+import { cn } from '@/utils/cn';
+
+interface BedroomTabsProps {
+  selected: string;
+  onSelect: (value: string) => void;
+}
+
+export default function BedroomTabs({ selected, onSelect }: BedroomTabsProps) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {BEDROOM_FILTERS.map((tab) => (
+        <button
+          key={tab.value}
+          type="button"
+          onClick={() => onSelect(tab.value)}
+          className={cn(
+            'rounded-[10px] border px-6 py-3 text-sm font-medium transition',
+            selected === tab.value
+              ? 'border-[#d9d9d9] bg-[#f7f4f0] text-[#333333]'
+              : 'border-[#e2e2e2] bg-white text-[#575757] hover:border-[#d0d0d0]'
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/hotel/FilterSidebar.tsx
+++ b/src/components/hotel/FilterSidebar.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { HOTEL_CATEGORIES, HOTEL_LOCATIONS } from '@/mockData/hotels';
+import { cn } from '@/utils/cn';
+
+interface FilterSidebarProps {
+  selectedCategories: string[];
+  selectedLocations: string[];
+  minPrice: number;
+  maxPrice: number;
+  onCategoryToggle: (category: string) => void;
+  onLocationToggle: (location: string) => void;
+  onMinPriceChange: (value: number) => void;
+  onMaxPriceChange: (value: number) => void;
+}
+
+const PRICE_BARS = [
+  { id: 'bar-1', height: 10 },
+  { id: 'bar-2', height: 18 },
+  { id: 'bar-3', height: 24 },
+  { id: 'bar-4', height: 20 },
+  { id: 'bar-5', height: 28 },
+  { id: 'bar-6', height: 16 },
+  { id: 'bar-7', height: 22 },
+  { id: 'bar-8', height: 14 },
+  { id: 'bar-9', height: 10 },
+  { id: 'bar-10', height: 26 },
+];
+
+function CheckboxRow({
+  checked,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  onChange: () => void;
+}) {
+  return (
+    <label className="flex items-center gap-3 text-sm text-[#2f2f2f]">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        className="h-4 w-4 rounded border-[#d8d8d8] text-[#ff6a00] focus:ring-[#ff6a00]"
+      />
+      {label}
+    </label>
+  );
+}
+
+export default function FilterSidebar({
+  selectedCategories,
+  selectedLocations,
+  minPrice,
+  maxPrice,
+  onCategoryToggle,
+  onLocationToggle,
+  onMinPriceChange,
+  onMaxPriceChange,
+}: FilterSidebarProps) {
+  const leftPercent = ((minPrice - 3200) / (206000 - 3200)) * 100;
+  const rightPercent = ((maxPrice - 3200) / (206000 - 3200)) * 100;
+
+  return (
+    <aside className="w-full border-b border-[#e8e1da] px-6 py-8 lg:w-[215px] lg:border-b-0 lg:border-r">
+      <section className="pb-8">
+        <h2 className="mb-5 text-[15px] font-semibold text-[#1d1d1d]">
+          Category
+        </h2>
+        <div className="space-y-3">
+          {HOTEL_CATEGORIES.map((category) => (
+            <CheckboxRow
+              key={category}
+              checked={selectedCategories.includes(category)}
+              label={category}
+              onChange={() => onCategoryToggle(category)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <div className="my-0 h-px bg-[#ebe3dd]" />
+
+      <section className="py-8">
+        <h2 className="mb-3 text-[15px] font-semibold text-[#1d1d1d]">
+          Price Range
+        </h2>
+        <p className="mb-5 text-sm text-[#2f2f2f]">
+          ${minPrice.toLocaleString()} - ${maxPrice.toLocaleString()}
+        </p>
+
+        <div className="relative px-2 pb-3">
+          <div className="mb-4 flex h-10 items-end justify-between gap-1">
+            {PRICE_BARS.map((bar) => (
+              <span
+                key={bar.id}
+                className="w-full rounded-t-sm bg-[#ffbf93]"
+                style={{ height: `${bar.height}px` }}
+              />
+            ))}
+          </div>
+          <div className="relative h-1 rounded-full bg-[#ffd7bd]">
+            <div
+              className="absolute h-1 rounded-full bg-[#ff6a00]"
+              style={{
+                left: `${leftPercent}%`,
+                width: `${Math.max(rightPercent - leftPercent, 4)}%`,
+              }}
+            />
+            <span
+              className="absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-white bg-[#ff6a00] shadow"
+              style={{ left: `calc(${leftPercent}% - 8px)` }}
+            />
+            <span
+              className="absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-white bg-[#ff6a00] shadow"
+              style={{ left: `calc(${rightPercent}% - 8px)` }}
+            />
+          </div>
+          <input
+            type="range"
+            min={3200}
+            max={206000}
+            step={100}
+            value={minPrice}
+            onChange={(event) =>
+              onMinPriceChange(Math.min(Number(event.target.value), maxPrice))
+            }
+            className="pointer-events-none absolute inset-x-0 top-0 h-full w-full appearance-none bg-transparent opacity-0"
+          />
+          <input
+            type="range"
+            min={3200}
+            max={206000}
+            step={100}
+            value={maxPrice}
+            onChange={(event) =>
+              onMaxPriceChange(Math.max(Number(event.target.value), minPrice))
+            }
+            className="pointer-events-none absolute inset-x-0 top-0 h-full w-full appearance-none bg-transparent opacity-0"
+          />
+        </div>
+      </section>
+
+      <div className="my-0 h-px bg-[#ebe3dd]" />
+
+      <section className="pt-8">
+        <h2 className="mb-5 text-[15px] font-semibold text-[#1d1d1d]">
+          Location
+        </h2>
+        <div className="space-y-3">
+          {HOTEL_LOCATIONS.map((location) => (
+            <CheckboxRow
+              key={location}
+              checked={selectedLocations.includes(location)}
+              label={location}
+              onChange={() => onLocationToggle(location)}
+            />
+          ))}
+        </div>
+      </section>
+    </aside>
+  );
+}

--- a/src/components/hotel/HotelHeader.tsx
+++ b/src/components/hotel/HotelHeader.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  FaBell,
+  FaChevronDown,
+  FaRegUserCircle,
+  FaSearch,
+} from 'react-icons/fa';
+
+export default function HotelHeader() {
+  return (
+    <header className="border-b border-[#e8e1da] bg-white">
+      <div className="mx-auto flex max-w-[1180px] items-center gap-4 px-5 py-5 lg:px-7">
+        <Link href="/" className="flex items-center gap-3">
+          <Image src="/img/logo.png" alt="SafeTrust" width={36} height={36} />
+          <span className="text-[24px] font-semibold tracking-[-0.03em] text-[#202020]">
+            SafeTrust
+          </span>
+        </Link>
+
+        <div className="mx-auto hidden w-full max-w-[430px] items-center rounded-full border border-[#d9d9d9] bg-[#f3f3f3] px-2 py-1.5 md:flex">
+          <button
+            type="button"
+            className="flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-[#2d2d2d] shadow-sm"
+          >
+            Rent
+            <FaChevronDown className="h-3.5 w-3.5" />
+          </button>
+          <div className="mx-3 h-6 w-px bg-[#d2d2d2]" />
+          <span className="text-sm text-[#8a8a8a]">
+            City, province or neighborhood
+          </span>
+          <FaSearch className="ml-auto h-4 w-4 text-[#5c5c5c]" />
+        </div>
+
+        <div className="ml-auto flex items-center gap-5">
+          <div className="relative">
+            <FaBell className="h-4 w-4 text-[#1f1f1f]" />
+            <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-[#ff6a00]" />
+          </div>
+          <span className="hidden text-sm font-semibold text-[#1f1f1f] lg:block">
+            Randall Valenciano
+          </span>
+          <div className="grid h-10 w-10 place-items-center rounded-full border border-[#d9d9d9] bg-[#f6f6f6]">
+            <FaRegUserCircle className="h-5 w-5 text-[#1f1f1f]" />
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/hotel/ImageGallery.tsx
+++ b/src/components/hotel/ImageGallery.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Image from 'next/image';
+
+interface ImageGalleryProps {
+  images: string[];
+  promoted?: boolean;
+}
+
+const THUMBNAIL_SLOTS = ['thumb-1', 'thumb-2', 'thumb-3'] as const;
+
+export default function ImageGallery({
+  images,
+  promoted = false,
+}: ImageGalleryProps) {
+  const [hero, ...thumbnails] = images;
+
+  return (
+    <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_130px]">
+      <div className="relative overflow-hidden rounded-[10px]">
+        <Image
+          src={hero}
+          alt="Apartment main image"
+          width={720}
+          height={520}
+          className="h-[260px] w-full object-cover sm:h-[320px] lg:h-[370px]"
+        />
+        {promoted ? (
+          <span className="absolute bottom-6 left-0 rounded-r-[10px] bg-[#ff6a00] px-5 py-2 text-xs font-semibold uppercase tracking-[0.02em] text-white">
+            Promoted
+          </span>
+        ) : null}
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 lg:grid-cols-1">
+        {thumbnails.slice(0, 3).map((image, index) => (
+          <div
+            key={THUMBNAIL_SLOTS[index] ?? image}
+            className="overflow-hidden rounded-[10px]"
+          >
+            <Image
+              src={image}
+              alt={`Apartment thumbnail ${index + 1}`}
+              width={160}
+              height={120}
+              className="h-[90px] w-full object-cover lg:h-[113px]"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/hotel/SuggestionsList.tsx
+++ b/src/components/hotel/SuggestionsList.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import type { HotelListing } from '@/@types/hotel';
+import Image from 'next/image';
+import { AiOutlineHeart } from 'react-icons/ai';
+
+interface SuggestionsListProps {
+  apartments: HotelListing[];
+  onSelect: (id: string) => void;
+}
+
+export default function SuggestionsList({
+  apartments,
+  onSelect,
+}: SuggestionsListProps) {
+  return (
+    <aside className="w-full border-b border-[#e8e1da] px-6 py-8 lg:w-[320px] lg:border-b-0 lg:border-r">
+      <div className="mb-6">
+        <h2 className="text-[28px] font-semibold tracking-[-0.03em] text-[#181818]">
+          Suggestions
+        </h2>
+        <p className="mt-4 text-sm text-[#202020]">
+          More than 200 units available
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {apartments.map((apartment) => (
+          <button
+            key={apartment.id}
+            type="button"
+            onClick={() => onSelect(apartment.id)}
+            className="flex w-full items-center gap-3 rounded-[8px] border border-[#dfd9d2] bg-white px-3 py-3 text-left transition hover:border-[#cfc6bc] hover:shadow-sm"
+          >
+            <div className="overflow-hidden rounded-[6px]">
+              <Image
+                src={apartment.images[0]}
+                alt={apartment.name}
+                width={78}
+                height={64}
+                className="h-[64px] w-[78px] object-cover"
+              />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="truncate text-base font-semibold text-[#1d1d1d]">
+                    {apartment.name}
+                  </h3>
+                  <p className="line-clamp-2 text-[11px] leading-[1.35] text-[#8a8a8a]">
+                    {apartment.address}
+                  </p>
+                </div>
+                <AiOutlineHeart className="h-5 w-5 shrink-0 text-[#ff2c2c]" />
+              </div>
+
+              <div className="mt-3 flex items-end justify-between gap-3">
+                <p className="text-[12px] text-[#6f6f6f]">
+                  {apartment.bedrooms}bd ·{' '}
+                  {apartment.petFriendly ? 'pet friendly' : 'no pets'} ·{' '}
+                  {apartment.bathrooms} ba
+                </p>
+                <span className="text-[28px] font-semibold leading-none text-[#10a156]">
+                  ${apartment.price.toLocaleString()}
+                </span>
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/hotel/index.ts
+++ b/src/components/hotel/index.ts
@@ -1,0 +1,9 @@
+export { default as HotelHeader } from './HotelHeader';
+export { default as ApartmentCard } from './ApartmentCard';
+export { default as ApartmentGrid } from './ApartmentGrid';
+export { default as FilterSidebar } from './FilterSidebar';
+export { default as BedroomTabs } from './BedroomTabs';
+export { default as ApartmentDetail } from './ApartmentDetail';
+export { default as ImageGallery } from './ImageGallery';
+export { default as SuggestionsList } from './SuggestionsList';
+export { default as AmenityIcons } from './AmenityIcons';

--- a/src/mockData/hotels.ts
+++ b/src/mockData/hotels.ts
@@ -1,0 +1,163 @@
+import type { HotelListing } from '@/@types/hotel';
+
+export const STUB_HOTELS: HotelListing[] = [
+  {
+    id: '1',
+    name: 'La sabana sur',
+    address: '329 Calle santos, paseo colón, San José',
+    price: 4058,
+    bedrooms: 2,
+    bathrooms: 1,
+    petFriendly: true,
+    promoted: true,
+    images: [
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+    ],
+    category: 'Family',
+    location: 'San José',
+    owner: { name: 'Alberto Casas', avatar: '/img/person.png' },
+    description:
+      'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry’s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.',
+    favorite: false,
+  },
+  {
+    id: '2',
+    name: 'Los yoses',
+    address: '329 Calle santos, paseo colón, San José',
+    price: 4000,
+    bedrooms: 2,
+    bathrooms: 1,
+    petFriendly: true,
+    promoted: false,
+    images: [
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+    ],
+    category: 'Students',
+    location: 'San José',
+    owner: { name: 'Alberto Casas', avatar: '/img/person.png' },
+    description:
+      'Compact apartment near key routes with bright interiors and fast access to the city center.',
+    favorite: false,
+  },
+  {
+    id: '3',
+    name: 'Paseo Colón Loft',
+    address: '225 Avenida central, paseo colón, San José',
+    price: 3980,
+    bedrooms: 1,
+    bathrooms: 1,
+    petFriendly: false,
+    promoted: false,
+    images: [
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+    ],
+    category: 'Travelers',
+    location: 'San José',
+    owner: { name: 'Randall Valenciano', avatar: '/img/person.png' },
+    description:
+      'Loft-style living with clean finishes, natural light, and walkable access to major amenities.',
+    favorite: true,
+  },
+  {
+    id: '4',
+    name: 'Heredia Central',
+    address: '101 Calle norte, Heredia centro, Heredia',
+    price: 4120,
+    bedrooms: 3,
+    bathrooms: 2,
+    petFriendly: true,
+    promoted: true,
+    images: [
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+    ],
+    category: 'Family',
+    location: 'Heredia',
+    owner: { name: 'María López', avatar: '/img/person.png' },
+    description:
+      'Larger family-ready floor plan with flexible living space and strong natural ventilation.',
+    favorite: false,
+  },
+  {
+    id: '5',
+    name: 'Alajuela Heights',
+    address: '78 Ruta 3, Alajuela, Alajuela',
+    price: 3895,
+    bedrooms: 2,
+    bathrooms: 1,
+    petFriendly: false,
+    promoted: false,
+    images: [
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+    ],
+    category: 'Travelers',
+    location: 'Alajuela',
+    owner: { name: 'Luis Salas', avatar: '/img/person.png' },
+    description:
+      'Quiet rental with a warm palette, ideal for medium stays and airport-adjacent access.',
+    favorite: true,
+  },
+  {
+    id: '6',
+    name: 'Cartago View',
+    address: '54 Vista real, Cartago, Cartago',
+    price: 4215,
+    bedrooms: 3,
+    bathrooms: 2,
+    petFriendly: true,
+    promoted: false,
+    images: [
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+      '/img/house1.jpg',
+    ],
+    category: 'Students',
+    location: 'Cartago',
+    owner: { name: 'Ana Ruiz', avatar: '/img/person.png' },
+    description:
+      'Balanced shared-living layout with comfortable bedrooms and a practical amenity mix.',
+    favorite: false,
+  },
+];
+
+export const HOTEL_CATEGORIES = ['Family', 'Students', 'Travelers'] as const;
+
+export const HOTEL_LOCATIONS = [
+  'San José',
+  'Heredia',
+  'Alajuela',
+  'Cartago',
+  'Puntarenas',
+  'Guanacaste',
+  'Limón',
+] as const;
+
+export const BEDROOM_FILTERS = [
+  { label: 'All apartments', value: 'all' },
+  { label: '1 bedroom', value: '1' },
+  { label: '2 bedrooms', value: '2' },
+  { label: '3 bedrooms', value: '3' },
+] as const;
+
+export function getHotelById(id: string) {
+  return STUB_HOTELS.find((hotel) => hotel.id === id) ?? STUB_HOTELS[0];
+}
+
+export function getSuggestedHotels(activeId: string) {
+  return STUB_HOTELS.filter((hotel) => hotel.id !== activeId).slice(0, 5);
+}


### PR DESCRIPTION
Closes #260
Closes #261

## Changes

- added the `/hotel` listing page with image-matched layout sections: filter rail, sort row, bedroom tabs, and responsive apartment card grid
- added the `/hotel/[id]` apartment detail page with suggestions sidebar, gallery, owner block, amenity row, and orange `BOOK` CTA
- added a minimal `/hotel/[id]/escrow/create` route so the `BOOK` button lands on a valid screen instead of a 404
- introduced hotel-specific stub data and reusable components for cards, filters, gallery, amenity icons, suggestions, and shared header UI

## Testing

- `npx biome check app/hotel src/components/hotel src/mockData/hotels.ts src/@types/hotel.ts`
- `npm run build`

## Notes

- I matched the two GitHub issue screenshots directly for layout, spacing, and hierarchy using the provided image attachments as the reference
- the repo still has unrelated global lint/type/env debt outside this hotel slice, so the work here was kept scoped to the assigned frontend routes and components
