### PR TITLE
feat(dashboard): add My Escrows overview card with escrow count

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,9 +5,8 @@ import { MainWalletSelectionModal } from "@/components/auth/wallet/components/Ma
 import { WalletSelectionModal } from "@/components/auth/wallet/components/WalletSelectionModal";
 import { MetaMaskWalletModal } from "@/components/auth/wallet/components/MetaMaskWalletModal";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { useGlobalAuthenticationStore } from "@/core/store/data";
+import { EscrowOverviewCard } from "@/components/escrow/EscrowOverviewCard";
 import { Wallet } from "lucide-react";
 import { CacheStatus } from "@/components/performance/CacheStatus";
 
@@ -62,11 +61,7 @@ const DashboardPage = () => {
         )}
       </div>
 
-      <div className="mt-8">
-        <h3 className="text-lg font-medium mb-4">Active Escrows</h3>
-        {/* TODO: wire in Batch N — GET_ESCROW_TRANSACTIONS via Apollo once backend is connected */}
-        <p className="text-sm text-gray-500 italic">No escrows found.</p>
-      </div>
+      <EscrowOverviewCard />
 
       {/* Wallet Connection Modals */}
       <MainWalletSelectionModal

--- a/src/components/escrow/EscrowOverviewCard.tsx
+++ b/src/components/escrow/EscrowOverviewCard.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { useWalletContext } from "@/components/tw-blocks/wallet-kit/WalletProvider";
+import { useEscrowsBySignerQuery } from "@/components/tw-blocks/tanstack/useEscrowsBySignerQuery";
+
+/**
+ * Mirrors EscrowDashboard "Total Escrows" (useEscrowsBySignerQuery, active + validateOnChain).
+ */
+export function EscrowOverviewCard() {
+  const { walletAddress } = useWalletContext();
+  const signer = walletAddress ?? "";
+
+  const { data: myEscrows = [], isLoading } = useEscrowsBySignerQuery({
+    signer,
+    enabled: !!signer,
+    validateOnChain: true,
+    isActive: true,
+  });
+
+  const total = myEscrows.length;
+
+  const countDisplay = !signer ? (
+    <span className="text-muted-foreground">—</span>
+  ) : isLoading ? (
+    <span className="text-muted-foreground">…</span>
+  ) : (
+    total
+  );
+
+  return (
+    <div className="rounded-lg border p-4 bg-card">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-semibold">My Escrows</h3>
+        <Link
+          href="/dashboard/escrow-dashboard"
+          className="text-sm text-primary hover:underline shrink-0"
+        >
+          View all escrows →
+        </Link>
+      </div>
+
+      <div className="mb-3">
+        <p className="text-3xl font-bold tabular-nums">{countDisplay}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">Total escrows</p>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Monitor escrows where you are approver, marker, or releaser.
+      </p>
+      <Link href="/dashboard/escrow-dashboard">
+        <Button variant="outline" className="mt-3 w-full">
+          Open Escrow Dashboard
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/escrow/EscrowOverviewCard.tsx
+++ b/src/components/escrow/EscrowOverviewCard.tsx
@@ -49,11 +49,9 @@ export function EscrowOverviewCard() {
       <p className="text-sm text-muted-foreground">
         Monitor escrows where you are approver, marker, or releaser.
       </p>
-      <Link href="/dashboard/escrow-dashboard">
-        <Button variant="outline" className="mt-3 w-full">
-          Open Escrow Dashboard
-        </Button>
-      </Link>
+      <Button variant="outline" className="mt-3 w-full" asChild>
+        <Link href="/dashboard/escrow-dashboard">Open Escrow Dashboard</Link>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
closes #264

## Description
Implements the post–Issues 1/2 follow-up: the main dashboard (/dashboard) now has a clear Escrow Overview entry that matches the product spec.

The My Escrows card reuses the same data path as EscrowDashboard for the Total escrows figure (useWalletContext + useEscrowsBySignerQuery with isActive: true and validateOnChain: true), so the number stays aligned with the escrow dashboard stat cards. It includes View all escrows → and a full-width Open Escrow Dashboard control, both pointing to /dashboard/escrow-dashboard, plus the short copy about approver / marker / releaser.

## Changes
Add src/components/escrow/EscrowOverviewCard.tsx
Mount the card on src/app/dashboard/page.tsx (after the wallet welcome block)
## How to test
Open /dashboard with a connected wallet (so the provider has a signer when applicable).
Confirm the Total escrows value matches Escrow Dashboard → Total Escrows for the same wallet.
Use View all escrows → and Open Escrow Dashboard; both should go to /dashboard/escrow-dashboard.
With no wallet, confirm the total shows a placeholder and the page still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard now features a dynamic escrow overview card, replacing the previous static placeholder
  * The new card displays your active on-chain escrows with real-time blockchain data
  * Added convenient navigation links to access the full escrow dashboard for detailed management and operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->