### PR TITLE
feat: replace logo in dashboard navbar with new SafeTrust brand logo

### DIFF
--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -28,9 +28,11 @@ export const Header = ({ onMenuClick }: HeaderProps) => {
 
               <Link href="/" className="flex items-center shrink-0">
                 <img
-                  src="/img/logo.png"
+                  src="/img/logo-new.png"
                   alt="SafeTrust Logo"
-                  className="h-8 w-auto"
+                  width={40}
+                  height={40}
+                  className="w-auto h-auto"
                 />
                 <span className="hidden sm:block text-xl font-semibold text-gray-800 dark:text-white ml-2">
                   SafeTrust


### PR DESCRIPTION
This PR updates the dashboard header logo to the new SafeTrust brand mark and ensures the logo is displayed at the correct size and styling.

- Replaced the old `/img/logo.png` reference with `/img/logo-new.png`
- Updated the dashboard header logo to render at `40x40`
- Kept the `SafeTrust` wordmark visible next to the logo
- Ensures the new logo appears consistently in the authenticated area without layout shift

Affected file:
- `src/components/layouts/Header.tsx`

Closes #280