### PR TITLE
feat: replace logo in Register.tsx with new SafeTrust brand logo

### DIFF
--- a/src/components/auth/Register.tsx
+++ b/src/components/auth/Register.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import Illustration from "@/components/auth/ui/Illustration";
+
+export default function RegisterPage() {
+  return (
+    <div className="flex min-h-screen">
+      <div className="flex w-full flex-col items-center justify-center px-4 md:w-1/2">
+        <div className="w-full max-w-sm space-y-6">
+          <div className="flex items-center space-x-2">
+            <Image src="/img/logo-new.png" alt="SafeTrust" width={40} height={40} />
+            <h1 className="text-2xl font-bold">SafeTrust</h1>
+          </div>
+
+          <form className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Full Name</Label>
+              <Input id="name" placeholder="Enter your full name" required />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="phone">Phone Number</Label>
+              <div className="flex gap-2">
+                <Select defaultValue="+506">
+                  <SelectTrigger className="w-[100px]">
+                    <SelectValue placeholder="Code" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="+506">+506</SelectItem>
+                    <SelectItem value="+1">+1</SelectItem>
+                    <SelectItem value="+52">+52</SelectItem>
+                    <SelectItem value="+34">+34</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  id="phone"
+                  type="tel"
+                  placeholder="Enter your phone number"
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="location">Location</Label>
+              <Select>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select your location" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="cr">Costa Rica</SelectItem>
+                  <SelectItem value="us">United States</SelectItem>
+                  <SelectItem value="mx">Mexico</SelectItem>
+                  <SelectItem value="es">Spain</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="Enter your email"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="Enter your password"
+                required
+              />
+            </div>
+
+            <Button
+              type="submit"
+              className="w-full bg-[#2857B8] hover:bg-[#2857B8]/90"
+            >
+              Sign Up
+            </Button>
+          </form>
+
+          <div className="text-center text-sm">
+            Already have an account?{" "}
+            <Link href="/" className="text-[#2857B8] hover:underline">
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <Illustration />
+    </div>
+  );
+}


### PR DESCRIPTION
This PR updates the SafeTrust Register page to use the new official brand logo in place of the old authentication logo.

- Replaced the existing `/img/logo.png` reference in `src/components/auth/Register.tsx`
- Updated the logo rendering to use `/img/logo-new.png`
- Increased the displayed logo size to `40x40` to match the Login page styling
- Preserved the `SafeTrust` wordmark next to the logo
- Ensures the Register page layout remains stable with no visual shift

Files changed:
- `src/components/auth/Register.tsx`

Closes #279