### PR TITLE
feat(escrow): complete dark mode audit for EscrowDashboard (#286)

### DIFF
--- a/src/components/dashboard/EscrowDashboard.tsx
+++ b/src/components/dashboard/EscrowDashboard.tsx
@@ -130,7 +130,7 @@ export function EscrowDashboard({
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary dark:border-white"></div>
       </div>
     );
   }
@@ -165,7 +165,7 @@ export function EscrowDashboard({
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Total Escrows</p>
-                <p className="text-2xl font-bold mt-1">{escrows.length}</p>
+                <p className="text-2xl font-bold mt-1 dark:text-white">{escrows.length}</p>
               </div>
               <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-900/30">
                 <svg className="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -211,7 +211,7 @@ export function EscrowDashboard({
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Total Value</p>
-                <p className="text-2xl font-bold mt-1">
+                <p className="text-2xl font-bold mt-1 dark:text-white">
                   ${escrows.reduce((sum, e) => sum + e.amount, 0).toLocaleString()}
                 </p>
               </div>

--- a/src/components/dashboard/EscrowTable.tsx
+++ b/src/components/dashboard/EscrowTable.tsx
@@ -111,39 +111,39 @@ export function EscrowTable({ escrows, userRole }: EscrowTableProps) {
   };
 
   return (
-    <div className="rounded-md border">
+    <div className="rounded-md border dark:border-gray-700">
       <Table>
         <TableHeader>
-          <TableRow>
-            <TableHead className="w-[50px]">
+          <TableRow className="dark:border-gray-700">
+            <TableHead className="w-[50px] dark:text-gray-200">
               <Checkbox />
             </TableHead>
-            <TableHead>Booking ID</TableHead>
-            <TableHead>Hotel</TableHead>
-            <TableHead>Check-in</TableHead>
-            <TableHead>Check-out</TableHead>
-            <TableHead>Amount</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead className="text-right">Actions</TableHead>
+            <TableHead className="dark:text-gray-200">Booking ID</TableHead>
+            <TableHead className="dark:text-gray-200">Hotel</TableHead>
+            <TableHead className="dark:text-gray-200">Check-in</TableHead>
+            <TableHead className="dark:text-gray-200">Check-out</TableHead>
+            <TableHead className="dark:text-gray-200">Amount</TableHead>
+            <TableHead className="dark:text-gray-200">Status</TableHead>
+            <TableHead className="text-right dark:text-gray-200">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {escrows.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={8} className="h-24 text-center">
+            <TableRow className="dark:border-gray-700">
+              <TableCell colSpan={8} className="h-24 text-center dark:text-gray-400">
                 No escrows found
               </TableCell>
             </TableRow>
           ) : (
             escrows.map((escrow) => (
-              <TableRow key={escrow.id}>
+              <TableRow key={escrow.id} className="dark:border-gray-700 dark:hover:bg-gray-800">
                 <TableCell>
                   <Checkbox />
                 </TableCell>
-                <TableCell className="font-medium">
+                <TableCell className="font-medium dark:text-white">
                   {escrow.metadata?.bookingId || 'N/A'}
                 </TableCell>
-                <TableCell>
+                <TableCell className="dark:text-white">
                   <div className="font-medium">
                     {escrow.metadata?.hotelName || 'N/A'}
                   </div>
@@ -151,9 +151,9 @@ export function EscrowTable({ escrows, userRole }: EscrowTableProps) {
                     {escrow.marker.slice(0, 6)}...{escrow.marker.slice(-4)}
                   </div>
                 </TableCell>
-                <TableCell>{formatDate(escrow.metadata?.checkInDate)}</TableCell>
-                <TableCell>{formatDate(escrow.metadata?.checkOutDate)}</TableCell>
-                <TableCell>
+                <TableCell className="dark:text-white">{formatDate(escrow.metadata?.checkInDate)}</TableCell>
+                <TableCell className="dark:text-white">{formatDate(escrow.metadata?.checkOutDate)}</TableCell>
+                <TableCell className="dark:text-white">
                   {formatCurrency(escrow.amount, escrow.asset.code)}
                 </TableCell>
                 <TableCell>

--- a/src/components/dashboard/EscrowsByStatus.tsx
+++ b/src/components/dashboard/EscrowsByStatus.tsx
@@ -93,13 +93,13 @@ export function EscrowsByStatus({ escrows, userRole }: EscrowsByStatusProps) {
     <div className="space-y-4">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between pb-2">
-          <CardTitle className="text-sm font-medium">
+          <CardTitle className="text-sm font-medium dark:text-white">
             Total Escrow Value
           </CardTitle>
           <DollarSign className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">
+          <div className="text-2xl font-bold dark:text-white">
             ${getTotalAmount().toLocaleString()}
           </div>
           <p className="text-xs text-muted-foreground">
@@ -112,13 +112,13 @@ export function EscrowsByStatus({ escrows, userRole }: EscrowsByStatusProps) {
         {getStatusStats().map((stat, i) => (
           <Card key={i}>
             <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-sm font-medium">
+              <CardTitle className="text-sm font-medium dark:text-white">
                 {stat.title}
               </CardTitle>
               <stat.icon className={`h-4 w-4 ${stat.color}`} />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{stat.value}</div>
+              <div className="text-2xl font-bold dark:text-white">{stat.value}</div>
               <p className="text-xs text-muted-foreground">{stat.description}</p>
             </CardContent>
           </Card>

--- a/src/components/dashboard/QuickActions.tsx
+++ b/src/components/dashboard/QuickActions.tsx
@@ -89,7 +89,7 @@ export function QuickActions({ userRole }: QuickActionsProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-medium">
+        <CardTitle className="text-sm font-medium dark:text-white">
           Quick Actions
         </CardTitle>
       </CardHeader>
@@ -99,15 +99,15 @@ export function QuickActions({ userRole }: QuickActionsProps) {
             <Button
               key={index}
               variant="outline"
-              className="w-full justify-start h-auto py-3 px-4"
+              className="w-full justify-start h-auto py-3 px-4 dark:border-gray-700 dark:hover:bg-gray-800"
               onClick={action.onClick}
             >
               <div className="flex items-center space-x-3">
-                <div className="p-1.5 rounded-md bg-primary/10 text-primary">
+                <div className="p-1.5 rounded-md bg-primary/10 text-primary dark:bg-primary/20">
                   <action.icon className="h-4 w-4" />
                 </div>
                 <div className="text-left">
-                  <div className="font-medium">{action.title}</div>
+                  <div className="font-medium dark:text-white">{action.title}</div>
                   <div className="text-xs text-muted-foreground">
                     {action.description}
                   </div>
@@ -117,18 +117,18 @@ export function QuickActions({ userRole }: QuickActionsProps) {
           ))}
         </div>
         
-        <div className="border-t pt-4">
+        <div className="border-t dark:border-gray-700 pt-4">
           <Button
             variant="ghost"
-            className="w-full justify-start h-auto py-3 px-4"
+            className="w-full justify-start h-auto py-3 px-4 dark:hover:bg-gray-800"
             onClick={helpAction.onClick}
           >
             <div className="flex items-center space-x-3">
-              <div className="p-1.5 rounded-md bg-muted">
+              <div className="p-1.5 rounded-md bg-muted dark:bg-gray-800">
                 <helpAction.icon className="h-4 w-4" />
               </div>
               <div className="text-left">
-                <div className="font-medium">{helpAction.title}</div>
+                <div className="font-medium dark:text-white">{helpAction.title}</div>
                 <div className="text-xs text-muted-foreground">
                   {helpAction.description}
                 </div>

--- a/src/components/dashboard/RecentActivity.tsx
+++ b/src/components/dashboard/RecentActivity.tsx
@@ -67,13 +67,13 @@ export function RecentActivity({ escrows }: RecentActivityProps) {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">
+          <CardTitle className="text-sm font-medium dark:text-white">
             Recent Activity
           </CardTitle>
-          <Activity className="h-4 w-4 text-muted-foreground" />
+          <Activity className="h-4 w-4 text-muted-foreground dark:text-gray-400" />
         </CardHeader>
         <CardContent>
-          <div className="text-sm text-muted-foreground text-center py-4">
+          <div className="text-sm text-muted-foreground dark:text-gray-400 text-center py-4">
             No recent activity
           </div>
         </CardContent>
@@ -84,10 +84,10 @@ export function RecentActivity({ escrows }: RecentActivityProps) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">
+        <CardTitle className="text-sm font-medium dark:text-white">
           Recent Activity
         </CardTitle>
-        <Activity className="h-4 w-4 text-muted-foreground" />
+        <Activity className="h-4 w-4 text-muted-foreground dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
         {recentEscrows.map((escrow) => (
@@ -97,7 +97,7 @@ export function RecentActivity({ escrows }: RecentActivityProps) {
             </div>
             <div className="flex-1">
               <div className="flex justify-between">
-                <p className="text-sm font-medium leading-none">
+                <p className="text-sm font-medium leading-none dark:text-white">
                   {getActivityMessage(escrow)}
                 </p>
                 <Badge 
@@ -107,11 +107,11 @@ export function RecentActivity({ escrows }: RecentActivityProps) {
                   {escrow.status.replace(/_/g, ' ')}
                 </Badge>
               </div>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-xs text-muted-foreground dark:text-gray-400 mt-1">
                 {new Date(escrow.updatedAt).toLocaleString()}
               </p>
               
-              <div className="mt-1 text-xs text-muted-foreground">
+              <div className="mt-1 text-xs text-muted-foreground dark:text-gray-400">
                 {escrow.metadata?.hotelName && (
                   <span className="block truncate">
                     {escrow.metadata.hotelName}

--- a/src/components/escrow/EscrowCard.tsx
+++ b/src/components/escrow/EscrowCard.tsx
@@ -92,15 +92,15 @@ export function EscrowCard({
         {/* Loading state */}
         {isLoading && (
           <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary dark:border-white"></div>
           </div>
         )}
 
         {/* Error state */}
         {error && !isLoading && (
           <div className="text-center py-8">
-            <div className="text-red-500 text-sm mb-2">Failed to load escrows</div>
-            <p className="text-xs text-gray-500">{error.message}</p>
+            <div className="text-red-500 dark:text-red-400 text-sm mb-2">Failed to load escrows</div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">{error.message}</p>
           </div>
         )}
 
@@ -122,8 +122,8 @@ export function EscrowCard({
                 />
               </svg>
             </div>
-            <p className="text-sm text-gray-500">No escrows found</p>
-            <p className="text-xs text-gray-400 mt-1">
+            <p className="text-sm text-gray-500 dark:text-gray-400">No escrows found</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
               Escrows where you are the {role} will appear here
             </p>
           </div>
@@ -183,7 +183,7 @@ function EscrowItem({
     >
       <div className="flex items-start justify-between gap-2 mb-2">
         <div className="flex-1 min-w-0">
-          <h4 className="text-sm font-semibold truncate">{title}</h4>
+          <h4 className="text-sm font-semibold truncate dark:text-white">{title}</h4>
           {contractId ? (
             <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
               {contractId.substring(0, 8)}...{contractId.substring(contractId.length - 6)}

--- a/src/components/escrow/EscrowDashboard.tsx
+++ b/src/components/escrow/EscrowDashboard.tsx
@@ -354,7 +354,7 @@ function StatCard({
           <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
             {title}
           </p>
-          <p className="text-2xl font-bold mt-1">{value}</p>
+          <p className="text-2xl font-bold mt-1 dark:text-white">{value}</p>
         </div>
         <div className={`p-3 rounded-lg ${colorClasses[color]}`}>
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
closes #286

## Description
Completes the full dark mode audit for the `EscrowDashboard` component tree, addressing all known gaps where elements failed to render with correct dark mode contrast or variants.

Depends on #275

### Changes Made
- **StatCards & EscrowDashboard**: Added `dark:text-white` to count numbers and `dark:border-white` to the loading spinner.
- **EscrowsByStatus**: Added `dark:text-white` to internal labels, status rows, and values.
- **EscrowTable**: Implemented `dark:border-gray-700`, `dark:hover:bg-gray-800`, `dark:text-gray-200`, and `dark:text-white` to table rows, headers, hover states, and cell text.
- **QuickActions**: Applied `dark:hover:bg-gray-800`, `dark:border-gray-700`, `dark:text-white`, and updated primary icons to `dark:bg-primary/20`.
- **RecentActivity**: Added `dark:text-white` to activity items and `dark:text-gray-400` to timestamps.
- **EscrowCard**: Updated the empty/error state texts to use `dark:text-gray-400` and `dark:text-red-400`, and updated the loading spinner `border` visibility.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] My code follows the atomic commit and branch naming guidelines.
- [x] I have tested the changes locally to verify all contrast issues are fixed.
- [x] Verified missing utility classes against the provided audit `grep` command.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode support across the dashboard with improved text contrast and element visibility, including stat cards displaying numeric values, data tables with borders and row styling, status badge cards, quick action buttons, and activity feed text to ensure optimal readability in dark theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->