### PR TITLE
Feat/upgrade theme toggle

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { MetaMaskWalletModal } from "@/components/auth/wallet/components/MetaMas
 import { WalletSelectionModal } from "@/components/auth/wallet/components/WalletSelectionModal";
 import { useMultiWallet } from "@/components/auth/wallet/hooks/multi-wallet.hook";
 import { CacheStatus } from "@/components/performance/CacheStatus";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import { Button } from "@/components/ui/button";
 import { useGlobalAuthenticationStore } from "@/core/store/data";
 import { getRoleBasedRedirect, getUserRole } from "@/utils/role-utils";

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,2 @@
+// Re-export from canonical location
+export { ThemeToggle, default } from '@/components/ui/ThemeToggle';

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -16,7 +16,7 @@ export const Header = ({ onMenuClick }: HeaderProps) => {
     <>
       <header className="fixed top-0 left-0 right-0 z-50 bg-white shadow-sm dark:border-b dark:border-gray-800 dark:bg-gray-900">
         <div className="max-w-7xl mx-auto px-4">
-          <div className="flex h-16 items-center gap-3 overflow-hidden sm:gap-4">
+          <div className="flex h-16 items-center gap-3 sm:gap-4">
             <div className="flex min-w-0 items-center gap-2">
               <Button
                 variant="ghost"

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,21 +1,52 @@
-import React from "react";
-import { useTheme } from "next-themes";
-import { FaSun, FaMoon } from "react-icons/fa";
+'use client';
 
-export const ThemeToggle: React.FC = () => {
-  const { theme, setTheme } = useTheme();
+import { useTheme } from '@/hooks/useTheme';
+
+export function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+  const isDark = theme === 'dark';
 
   return (
-    <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-      aria-label="Toggle theme"
-    >
-      {theme === "dark" ? (
-        <FaSun className="w-5 h-5 text-yellow-500" />
-      ) : (
-        <FaMoon className="w-5 h-5 text-gray-700" />
-      )}
-    </button>
+    <div className="inline-flex shrink-0 items-center gap-2 select-none">
+      <span
+        className={`text-xs font-semibold tracking-wide uppercase transition-colors duration-300 ${
+          isDark ? 'text-white' : 'text-gray-400'
+        }`}
+      >
+        Dark
+      </span>
+
+      <button
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+        aria-pressed={isDark}
+        className={`relative w-12 h-6 rounded-full transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+          isDark ? 'bg-gray-600' : 'bg-gray-300'
+        }`}
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow-md transition-transform duration-300 ${
+            isDark ? 'translate-x-0' : 'translate-x-6'
+          }`}
+        />
+      </button>
+
+      <span
+        className={`text-xs font-semibold tracking-wide uppercase transition-colors duration-300 ${
+          !isDark ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'
+        }`}
+      >
+        Light
+      </span>
+    </div>
   );
-};
+}
+
+// Keep default export for backwards compatibility
+export default ThemeToggle;

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -2,19 +2,54 @@
 
 import { useTheme } from '@/hooks/useTheme';
 
+// Moon icon (dark mode)
+function MoonIcon({ active }: { active: boolean }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={`w-4 h-4 transition-colors duration-300 ${
+        active ? 'text-white' : 'text-gray-400'
+      }`}
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+    </svg>
+  );
+}
+
+// Sun icon (light mode)
+function SunIcon({ active }: { active: boolean }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={`w-4 h-4 transition-colors duration-300 ${
+        active ? 'text-yellow-500' : 'text-gray-400'
+      }`}
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <line x1="12" y1="21" x2="12" y2="23" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <line x1="1" y1="12" x2="3" y2="12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <line x1="21" y1="12" x2="23" y2="12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 export function ThemeToggle() {
   const { theme, toggle } = useTheme();
   const isDark = theme === 'dark';
 
   return (
     <div className="inline-flex shrink-0 items-center gap-2 select-none">
-      <span
-        className={`text-xs font-semibold tracking-wide uppercase transition-colors duration-300 ${
-          isDark ? 'text-white' : 'text-gray-400'
-        }`}
-      >
-        Dark
-      </span>
+      {/* Moon — lights up when dark mode is active */}
+      <MoonIcon active={isDark} />
 
       <button
         onClick={toggle}
@@ -37,13 +72,8 @@ export function ThemeToggle() {
         />
       </button>
 
-      <span
-        className={`text-xs font-semibold tracking-wide uppercase transition-colors duration-300 ${
-          !isDark ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'
-        }`}
-      >
-        Light
-      </span>
+      {/* Sun — lights up when light mode is active */}
+      <SunIcon active={!isDark} />
     </div>
   );
 }

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -45,7 +45,7 @@ const Header: React.FC = () => {
           </span>
         </div>
 
-        <div className="flex items-center space-x-4 ml-auto">
+        <div className="flex items-center space-x-4 ml-auto pr-2">
           <button
             onClick={toggleMobileMenu}
             className="lg:hidden p-2 text-gray-800 dark:text-white focus:outline-none transition-transform duration-300 ease-in-out"


### PR DESCRIPTION


# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

Upgrades `ThemeToggle.tsx` from a simple icon button to a pill-shaped slider toggle with moon/sun icons, consistent with the design reference in issue #352. All existing `useTheme` hook behavior, localStorage persistence, and flash prevention are preserved.

## 🌀 Summary of Changes

- **Replaced `src/components/ui/ThemeToggle.tsx`**: Removed the old icon-only button using `next-themes`. Implemented a pill-shaped slider with a sliding circle, moon icon (left) and sun icon (right) — moon brightens in dark mode, sun brightens in light mode. Now uses the project's own `useTheme` hook from `@/hooks/useTheme`.
- **Added `src/components/ThemeToggle.tsx`**: Re-export shim to fix the broken import in `Sidebar.tsx` which referenced `@/components/ThemeToggle` (a path that did not exist).
- **Fixed `src/app/dashboard/page.tsx`**: Added the missing `ThemeToggle` import that was already being used but never imported, resolving a TypeScript error.
- **Fixed `src/components/layouts/Header.tsx`**: Removed `overflow-hidden` from the header flex row that was clipping the toggle at the viewport edge.
- **Fixed `src/layouts/Header.tsx`**: Added `pr-2` to the right items container to prevent the toggle from sitting flush against the viewport edge.

## 🛠 Testing

### Evidence Before Solution
- Simple sun/moon icon button with no pill or slider
- `Sidebar.tsx` had a broken import pointing to `@/components/ThemeToggle` which did not exist
- `dashboard/page.tsx` used `ThemeToggle` without importing it (TypeScript error)
- Toggle labels/content clipped at viewport edge in the header

- **Video**: [[Link to Loom video](https://loom.com/)](https://loom.com)

### Evidence After Solution
- Pill-shaped slider renders correctly with moon icon left and sun icon right
- Circle slides smoothly between positions on click (300ms transition)
- Active icon is visually prominent (white moon / yellow sun), inactive icon is dimmed gray
- localStorage persistence and flash prevention from #329 still work
- Toggle renders correctly inside `Sidebar.tsx`, `Header.tsx`, and all auth pages without overflow or clipping
- `npm run build` passes with no new TypeScript errors

- **Video**: [[Link to Loom video](https://loom.com/)](https://loom.com)

https://github.com/user-attachments/assets/cdc809f3-4754-4d68-bad1-c0b14d018af7




## 📂 Related Issue

This pull request will **close #352** upon merging.


The Pull request needs to have the format mentioned below in the Git Guideline
- [[Contributing Guide](https://github.com/safetrustcr/Frontend/issues/34)](https://github.com/safetrustcr/Frontend/issues/34)
- [[Git Guidelines](https://github.com/safetrustcr/Frontend/issues/35)](https://github.com/safetrustcr/Frontend/issues/35)

🎉 Thank you for reviewing this PR! 🎉

-  Close #352 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme toggle now accessible in the dashboard header.

* **Style & UI**
  * Redesigned theme toggle component with improved visual styling and enhanced keyboard accessibility.
  * Adjusted header layout spacing for better alignment across responsive views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/safetrustcr/frontend-SafeTrust/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->