### PR TITLE
feat(sidebar): add Rent link to sidebar and import Building2 icon

### DIFF
--- a/src/components/layouts/SideBar.tsx
+++ b/src/components/layouts/SideBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { Bell, Heart, Shield, Users } from "lucide-react";
+import { Bell, Building2, Heart, Shield, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -53,13 +53,29 @@ export function SideBar({
           onClick={onClose}
           className={cn(
             "flex items-center gap-3 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full group relative dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
-            pathname === "/dashboard/escrow-dashboard" && "bg-accent font-medium dark:bg-gray-800 dark:text-white",
+            pathname === "/dashboard/escrow-dashboard" &&
+              "bg-accent font-medium dark:bg-gray-800 dark:text-white",
           )}
         >
           <Shield className="w-6 h-6 dark:text-gray-400" />
           <span className="md:hidden lg:block">Escrow Dashboard</span>
           <span className="hidden md:group-hover:block lg:group-hover:hidden absolute left-14 bg-popover text-popover-foreground px-2 py-1 rounded shadow-md text-xs z-50 whitespace-nowrap">
             Escrow Dashboard
+          </span>
+        </Link>
+        <Link
+          href="/hotel"
+          onClick={onClose}
+          className={cn(
+            "flex items-center gap-3 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full group relative dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
+            pathname === "/hotel" &&
+              "bg-accent font-medium dark:bg-gray-800 dark:text-white",
+          )}
+        >
+          <Building2 className="w-6 h-6 shrink-0 dark:text-gray-400" />
+          <span className="md:hidden lg:block">Rent</span>
+          <span className="hidden md:group-hover:block lg:group-hover:hidden absolute left-14 bg-popover text-popover-foreground px-2 py-1 rounded shadow-md text-xs z-50 whitespace-nowrap">
+            Rent
           </span>
         </Link>
         <Link
@@ -95,7 +111,8 @@ export function SideBar({
           href="/dashboard/users"
           className={cn(
             "flex items-center gap-2 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
-            pathname === "/dashboard/users" && "bg-accent font-medium dark:bg-gray-800 dark:text-white",
+            pathname === "/dashboard/users" &&
+              "bg-accent font-medium dark:bg-gray-800 dark:text-white",
           )}
         >
           <Users className="w-6 h-6 dark:text-gray-400" />

--- a/src/components/layouts/SideBar.tsx
+++ b/src/components/layouts/SideBar.tsx
@@ -66,6 +66,7 @@ export function SideBar({
         <Link
           href="/hotel"
           onClick={onClose}
+          aria-label="Rent"
           className={cn(
             "flex items-center gap-3 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full group relative dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
             pathname === "/hotel" &&


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

This pull request adds a new **Rent** navigation link to the Dashboard sidebar, allowing users to access the existing available rental listings page without manually entering the `/hotel` URL.

## 🌀 Summary of Changes

- Added a **Rent** navigation item after **Escrow Dashboard**.
- Added the Lucide React `Building2` icon.
- Linked the new navigation item to `/hotel`.
- Preserved the sidebar’s responsive styling, tooltip, and active state.

## 🛠 Testing

### Evidence After Solution

The Dashboard sidebar now displays a **Rent** option. Clicking it redirects the user to `/hotel`, where the available listings are displayed.

<img width="1894" height="711" alt="image" src="https://github.com/user-attachments/assets/9d819253-c234-49ed-9d1b-4b565aaaae72" />

https://www.loom.com/share/ee1dbc95438c419fbc06089dce04d1e8

This pull request will **close #373** upon merging.

---

### Make sure to follow the Git Guidelines for Atomic Commits and read Contributing Guide

The Pull request needs to have the format mentioned below in the Git Guideline

- [Contributing Guide](https://github.com/safetrustcr/Frontend/issues/34)
- [Git Guidelines](https://github.com/safetrustcr/Frontend/issues/35)

🎉 Thank you for reviewing this PR! 🎉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new hotel navigation menu item to the sidebar with active-state highlighting and convenient access from the main navigation bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->