### PR TITLE
feat(hotel): add dark mode support to /hotel listing page (#383)

### DIFF
--- a/src/app/hotel/page.tsx
+++ b/src/app/hotel/page.tsx
@@ -78,7 +78,7 @@ export default function HotelListingPage() {
   };
 
   return (
-    <div className="min-h-screen bg-white text-[#1c1c1c]">
+    <div className="min-h-screen bg-white text-[#1c1c1c] dark:bg-[#0b0f17] dark:text-[#e6e8ec]">
       <HotelHeader />
 
       <div className="mx-auto flex max-w-[1180px] flex-col lg:flex-row">
@@ -100,14 +100,14 @@ export default function HotelListingPage() {
         <main className="flex-1 px-6 py-8 lg:px-12">
           <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
             <div>
-              <h1 className="text-[24px] leading-tight text-[#1d1d1d] sm:text-[30px]">
+              <h1 className="text-[24px] leading-tight text-[#1d1d1d] dark:text-[#e6e8ec] sm:text-[30px]">
                 Available for rent in{' '}
                 <span className="font-semibold">Costa Rica, San José</span>
               </h1>
-              <p className="mt-3 text-sm text-[#515151]">204 units available</p>
+              <p className="mt-3 text-sm text-[#515151] dark:text-[#9aa4b2]">204 units available</p>
             </div>
 
-            <div className="flex items-center gap-2 text-sm text-[#202020]">
+            <div className="flex items-center gap-2 text-sm text-[#202020] dark:text-[#e6e8ec]">
               <BsSortDownAlt className="h-4 w-4" />
               <span>Sort by:</span>
               <span className="font-semibold text-[#ff6a00]">Relevance</span>

--- a/src/components/hotel/AmenityIcons.tsx
+++ b/src/components/hotel/AmenityIcons.tsx
@@ -19,13 +19,13 @@ function AmenityPill({
   return (
     <div className="flex items-center gap-2">
       <span
-        className={`grid rounded-full bg-[#fff1e7] text-[#ff6a00] ${
+        className={`grid rounded-full bg-[#fff1e7] text-[#ff6a00] dark:bg-[#2a2018] ${
           compact ? 'h-6 w-6 place-items-center' : 'h-8 w-8 place-items-center'
         }`}
       >
         {icon}
       </span>
-      <span className={`${compact ? 'text-[11px]' : 'text-sm'} text-[#6b7280]`}>
+      <span className={`${compact ? 'text-[11px]' : 'text-sm'} text-[#6b7280] dark:text-[#9aa4b2]`}>
         {label}
       </span>
     </div>

--- a/src/components/hotel/ApartmentCard.tsx
+++ b/src/components/hotel/ApartmentCard.tsx
@@ -21,7 +21,7 @@ export default function ApartmentCard({
     <button
       type="button"
       onClick={onClick}
-      className="group w-full overflow-hidden rounded-[16px] border border-[#e7e2dc] bg-white text-left transition hover:-translate-y-0.5 hover:shadow-[0_12px_30px_rgba(0,0,0,0.08)]"
+      className="group w-full overflow-hidden rounded-[16px] border border-[#e7e2dc] bg-white text-left transition hover:-translate-y-0.5 hover:shadow-[0_12px_30px_rgba(0,0,0,0.08)] dark:border-[#2a3340] dark:bg-[#141a24] dark:hover:shadow-[0_12px_30px_rgba(0,0,0,0.5)]"
     >
       <div className="relative">
         <Image
@@ -45,7 +45,7 @@ export default function ApartmentCard({
             <span className="text-[30px] font-semibold leading-none text-[#10a156]">
               {formatListingPrice(apartment.price)}
             </span>
-            <span className="pb-1 text-xs text-[#8b8b8b]">Per month</span>
+            <span className="pb-1 text-xs text-[#8b8b8b] dark:text-[#9aa4b2]">Per month</span>
           </div>
           <AiOutlineHeart
             className={cn(
@@ -58,10 +58,10 @@ export default function ApartmentCard({
         </div>
 
         <div className="space-y-1">
-          <h3 className="text-base font-semibold text-[#222222]">
+          <h3 className="text-base font-semibold text-[#222222] dark:text-[#e6e8ec]">
             {apartment.name}
           </h3>
-          <p className="line-clamp-1 text-xs text-[#8a8a8a]">
+          <p className="line-clamp-1 text-xs text-[#8a8a8a] dark:text-[#9aa4b2]">
             {apartment.address}
           </p>
         </div>

--- a/src/components/hotel/BedroomTabs.tsx
+++ b/src/components/hotel/BedroomTabs.tsx
@@ -19,8 +19,8 @@ export default function BedroomTabs({ selected, onSelect }: BedroomTabsProps) {
           className={cn(
             'rounded-[10px] border px-6 py-3 text-sm font-medium transition',
             selected === tab.value
-              ? 'border-[#d9d9d9] bg-[#f7f4f0] text-[#333333]'
-              : 'border-[#e2e2e2] bg-white text-[#575757] hover:border-[#d0d0d0]'
+              ? 'border-[#d9d9d9] bg-[#f7f4f0] text-[#333333] dark:border-[#2a3340] dark:bg-[#1c2430] dark:text-[#e6e8ec]'
+              : 'border-[#e2e2e2] bg-white text-[#575757] hover:border-[#d0d0d0] dark:border-[#2a3340] dark:bg-[#141a24] dark:text-[#9aa4b2] dark:hover:border-[#384352]'
           )}
         >
           {tab.label}

--- a/src/components/hotel/FilterSidebar.tsx
+++ b/src/components/hotel/FilterSidebar.tsx
@@ -38,12 +38,12 @@ function CheckboxRow({
   onChange: () => void;
 }) {
   return (
-    <label className="flex items-center gap-3 text-sm text-[#2f2f2f]">
+    <label className="flex items-center gap-3 text-sm text-[#2f2f2f] dark:text-[#e6e8ec]">
       <input
         type="checkbox"
         checked={checked}
         onChange={onChange}
-        className="h-4 w-4 rounded border-[#d8d8d8] text-[#ff6a00] focus:ring-[#ff6a00]"
+        className="h-4 w-4 rounded border-[#d8d8d8] text-[#ff6a00] focus:ring-[#ff6a00] dark:border-[#2a3340] dark:bg-[#1c2430]"
       />
       {label}
     </label>
@@ -64,9 +64,9 @@ export default function FilterSidebar({
   const rightPercent = ((maxPrice - 3200) / (206000 - 3200)) * 100;
 
   return (
-    <aside className="w-full border-b border-[#e8e1da] px-6 py-8 lg:w-[215px] lg:border-b-0 lg:border-r">
+    <aside className="w-full border-b border-[#e8e1da] px-6 py-8 dark:border-[#2a3340] lg:w-[215px] lg:border-b-0 lg:border-r">
       <section className="pb-8">
-        <h2 className="mb-5 text-[15px] font-semibold text-[#1d1d1d]">
+        <h2 className="mb-5 text-[15px] font-semibold text-[#1d1d1d] dark:text-[#e6e8ec]">
           Category
         </h2>
         <div className="space-y-3">
@@ -81,13 +81,13 @@ export default function FilterSidebar({
         </div>
       </section>
 
-      <div className="my-0 h-px bg-[#ebe3dd]" />
+      <div className="my-0 h-px bg-[#ebe3dd] dark:bg-[#2a3340]" />
 
       <section className="py-8">
-        <h2 className="mb-3 text-[15px] font-semibold text-[#1d1d1d]">
+        <h2 className="mb-3 text-[15px] font-semibold text-[#1d1d1d] dark:text-[#e6e8ec]">
           Price Range
         </h2>
-        <p className="mb-5 text-sm text-[#2f2f2f]">
+        <p className="mb-5 text-sm text-[#2f2f2f] dark:text-[#9aa4b2]">
           {formatListingPrice(minPrice)} - {formatListingPrice(maxPrice)}
         </p>
 
@@ -96,12 +96,12 @@ export default function FilterSidebar({
             {PRICE_BARS.map((bar) => (
               <span
                 key={bar.id}
-                className="w-full rounded-t-sm bg-[#ffbf93]"
+                className="w-full rounded-t-sm bg-[#ffbf93] dark:bg-[#3a2a1c]"
                 style={{ height: `${bar.height}px` }}
               />
             ))}
           </div>
-          <div className="relative h-1 rounded-full bg-[#ffd7bd]">
+          <div className="relative h-1 rounded-full bg-[#ffd7bd] dark:bg-[#3a2a1c]">
             <div
               className="absolute h-1 rounded-full bg-[#ff6a00]"
               style={{
@@ -143,10 +143,10 @@ export default function FilterSidebar({
         </div>
       </section>
 
-      <div className="my-0 h-px bg-[#ebe3dd]" />
+      <div className="my-0 h-px bg-[#ebe3dd] dark:bg-[#2a3340]" />
 
       <section className="pt-8">
-        <h2 className="mb-5 text-[15px] font-semibold text-[#1d1d1d]">
+        <h2 className="mb-5 text-[15px] font-semibold text-[#1d1d1d] dark:text-[#e6e8ec]">
           Location
         </h2>
         <div className="space-y-3">

--- a/src/components/hotel/HotelHeader.tsx
+++ b/src/components/hotel/HotelHeader.tsx
@@ -11,40 +11,40 @@ import {
 
 export default function HotelHeader() {
   return (
-    <header className="border-b border-[#e8e1da] bg-white">
+    <header className="border-b border-[#e8e1da] bg-white dark:border-[#2a3340] dark:bg-[#141a24]">
       <div className="mx-auto flex max-w-[1180px] items-center gap-4 px-5 py-5 lg:px-7">
         <Link href="/" className="flex items-center gap-3">
           <Image src="/img/logo.png" alt="SafeTrust" width={36} height={36} />
-          <span className="text-[24px] font-semibold tracking-[-0.03em] text-[#202020]">
+          <span className="text-[24px] font-semibold tracking-[-0.03em] text-[#202020] dark:text-[#e6e8ec]">
             SafeTrust
           </span>
         </Link>
 
-        <div className="mx-auto hidden w-full max-w-[430px] items-center rounded-full border border-[#d9d9d9] bg-[#f3f3f3] px-2 py-1.5 md:flex">
+        <div className="mx-auto hidden w-full max-w-[430px] items-center rounded-full border border-[#d9d9d9] bg-[#f3f3f3] px-2 py-1.5 dark:border-[#2a3340] dark:bg-[#1c2430] md:flex">
           <button
             type="button"
-            className="flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-[#2d2d2d] shadow-sm"
+            className="flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-[#2d2d2d] shadow-sm dark:bg-[#141a24] dark:text-[#e6e8ec]"
           >
             Rent
             <FaChevronDown className="h-3.5 w-3.5" />
           </button>
-          <div className="mx-3 h-6 w-px bg-[#d2d2d2]" />
-          <span className="text-sm text-[#8a8a8a]">
+          <div className="mx-3 h-6 w-px bg-[#d2d2d2] dark:bg-[#2a3340]" />
+          <span className="text-sm text-[#8a8a8a] dark:text-[#9aa4b2]">
             City, province or neighborhood
           </span>
-          <FaSearch className="ml-auto h-4 w-4 text-[#5c5c5c]" />
+          <FaSearch className="ml-auto h-4 w-4 text-[#5c5c5c] dark:text-[#9aa4b2]" />
         </div>
 
         <div className="ml-auto flex items-center gap-5">
           <div className="relative">
-            <FaBell className="h-4 w-4 text-[#1f1f1f]" />
+            <FaBell className="h-4 w-4 text-[#1f1f1f] dark:text-[#e6e8ec]" />
             <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-[#ff6a00]" />
           </div>
-          <span className="hidden text-sm font-semibold text-[#1f1f1f] lg:block">
+          <span className="hidden text-sm font-semibold text-[#1f1f1f] dark:text-[#e6e8ec] lg:block">
             Randall Valenciano
           </span>
-          <div className="grid h-10 w-10 place-items-center rounded-full border border-[#d9d9d9] bg-[#f6f6f6]">
-            <FaRegUserCircle className="h-5 w-5 text-[#1f1f1f]" />
+          <div className="grid h-10 w-10 place-items-center rounded-full border border-[#d9d9d9] bg-[#f6f6f6] dark:border-[#2a3340] dark:bg-[#1c2430]">
+            <FaRegUserCircle className="h-5 w-5 text-[#1f1f1f] dark:text-[#e6e8ec]" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What this does

Adds dark/light mode support to the `/hotel` listing page so it follows the global theme toggle, consistent with the rest of the dashboard.

Previously the listing page and its child components used hardcoded light colors and ignored the theme, so switching the toggle in the header had no visible effect on this page.

## Changes

Added `dark:` variants across the listing page and its components, following the existing dashboard convention (Tailwind `darkMode: "class"` with next-themes):

- `src/app/hotel/page.tsx`
- `src/components/hotel/HotelHeader.tsx`
- `src/components/hotel/FilterSidebar.tsx`
- `src/components/hotel/BedroomTabs.tsx`
- `src/components/hotel/ApartmentCard.tsx`
- `src/components/hotel/AmenityIcons.tsx`

## Notes

- Light mode is unchanged. Every existing light color is preserved and only paired with a `dark:` sibling, so there is no regression in the default theme.
- Brand colors (orange accent, price green, favorite red) are intentionally kept in both themes.
- Surfaces, borders, and secondary text use a consistent dark palette for readable contrast.

Closes #383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dark mode support now available across the hotel interface, including navigation headers, filter sidebars, apartment listings, amenity displays, and bedroom selection tabs for comfortable browsing in low-light conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->