### PR TITLE
feat: wire Guest View navigation in sidebar

### DIFF
--- a/src/components/layouts/SideBar.tsx
+++ b/src/components/layouts/SideBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { Bell, Building2, Heart, Home, PlusSquare, Shield, Users } from "lucide-react";
+import { Bell, Building2, Heart, Home, LayoutDashboard, PlusSquare, Shield, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LogoutButton } from "@/components/auth/LogoutButton";
@@ -62,6 +62,21 @@ export function SideBar({
           <span className="md:hidden lg:block">Escrow Dashboard</span>
           <span className="hidden md:group-hover:block lg:group-hover:hidden absolute left-14 bg-popover text-popover-foreground px-2 py-1 rounded shadow-md text-xs z-50 whitespace-nowrap">
             Escrow Dashboard
+          </span>
+        </Link>
+        <Link
+          href="/dashboard/guest"
+          onClick={onClose}
+          className={cn(
+            "flex items-center gap-3 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full group relative dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white",
+            pathname === "/dashboard/guest" &&
+              "bg-accent font-medium dark:bg-gray-800 dark:text-white",
+          )}
+        >
+          <LayoutDashboard className="w-6 h-6 shrink-0 dark:text-gray-400" />
+          <span className="md:hidden lg:block">Guest view</span>
+          <span className="hidden md:group-hover:block lg:group-hover:hidden absolute left-14 bg-popover text-popover-foreground px-2 py-1 rounded shadow-md text-xs z-50 whitespace-nowrap">
+            Guest view
           </span>
         </Link>
         <Link


### PR DESCRIPTION


# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

<!-- Briefly describe the purpose of the pull request. Explain the problem being solved or the functionality being implemented. -->

Add the missing "Guest View" sidebar link using the LayoutDashboard icon component, inserting it between the Escrow Dashboard and Rent links. This wires up the navigation to the existing /dashboard/guest route without altering page content. 

## 🌀 Summary of Changes

<!-- List the main changes made in the code. Include new features, bug fixes, or refactored components. -->

-Added LayoutDashboard icon import to src/components/layouts/SideBar.tsx
-Added "Guest view" navigation link in the sidebar between the Escrow Dashboard and Rent links, pointing to /dashboard/guest

## 🛠 Testing

### Evidence Before Solution

<!-- Describe the behavior or issue before applying the solution. Use Loom to record a video showing the problem. Provide a link to the video. -->

- **Video**: [Link to Loom video](https://loom.com)

### Evidence After Solution

<!-- Explain how the issue was fixed and demonstrate the corrected functionality. Use Loom to record another video showing the solution. Provide a link to the video. -->

- **Video**: [Link to Loom video](https://loom.com)

## 📂 Related Issue

<!-- Link the related issue so it automatically closes when this pull request is merged. -->

This pull request will close #392 upon merging.

---

### Make sure to follow the Git Guidelines for Atomic Commits and read Contributing Guide

The Pull request needs to have the format mentioned below in the Git Guideline

- [Contributing Guide ](https://github.com/safetrustcr/Frontend/issues/34)
- [Git Guidelines](https://github.com/safetrustcr/Frontend/issues/35)

🎉 Thank you for reviewing this PR! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Guest view** link in the sidebar for quicker access to the guest dashboard.
* **Bug Fixes**
  * Sidebar navigation now closes automatically after selecting **Guest view**, matching the behavior of other dashboard links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->