### PR TITLE
fix: notifications sidebar returns `404`

### DIFF
--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -61,22 +61,20 @@ export default function NotificationsPage() {
         {unreadCount > 0 && (
           <button
             onClick={markAllRead}
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            className="text-xs text-gray-400 hover:text-white transition-colors"
           >
             Mark all as read
           </button>
         )}
       </div>
 
-      <hr className="border-border" />
+      <hr className="border-gray-700" />
 
       {notifications.length === 0 && (
         <div className="flex flex-col items-center justify-center py-16 space-y-3">
-          <Bell className="h-10 w-10 text-muted-foreground" />
-          <p className="text-sm font-medium text-muted-foreground">
-            No notifications yet
-          </p>
-          <p className="text-xs text-muted-foreground">You are all caught up</p>
+          <Bell className="h-10 w-10 text-gray-600" />
+          <p className="text-sm font-medium text-gray-400">No notifications yet</p>
+          <p className="text-xs text-gray-500">You are all caught up</p>
         </div>
       )}
 

--- a/src/components/dashboard/NotificationItem.tsx
+++ b/src/components/dashboard/NotificationItem.tsx
@@ -1,9 +1,7 @@
-"use client";
-
-import { CheckCircle, AlertCircle, Info } from "lucide-react";
+import { CheckCircle, Info, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-type NotificationType = "info" | "success" | "warning";
+type NotificationType = "success" | "info" | "warning";
 
 interface NotificationItemProps {
   type: NotificationType;
@@ -11,13 +9,13 @@ interface NotificationItemProps {
   message: string;
   timestamp: string;
   read: boolean;
-  onClick?: () => void;
+  onClick: () => void;
 }
 
-const TYPE_ICON: Record<NotificationType, React.ReactNode> = {
-  info: <Info className="h-4 w-4 text-blue-400" />,
-  success: <CheckCircle className="h-4 w-4 text-green-400" />,
-  warning: <AlertCircle className="h-4 w-4 text-yellow-400" />,
+const ICON_MAP = {
+  success: <CheckCircle className="h-5 w-5 text-green-400" />,
+  info: <Info className="h-5 w-5 text-blue-400" />,
+  warning: <AlertTriangle className="h-5 w-5 text-yellow-400" />,
 };
 
 export function NotificationItem({
@@ -29,35 +27,28 @@ export function NotificationItem({
   onClick,
 }: NotificationItemProps) {
   return (
-    <div
+    <button
       onClick={onClick}
       className={cn(
-        "flex items-start gap-3 rounded-lg border p-4 cursor-pointer",
-        "transition-colors hover:bg-accent dark:hover:bg-gray-800",
+        "w-full text-left rounded-lg border p-4 transition-colors",
         read
-          ? "border-border bg-transparent"
-          : "border-border bg-accent/60 dark:bg-gray-800/60",
+          ? "border-gray-700 bg-transparent"
+          : "border-purple-700/40 bg-purple-900/10 hover:bg-purple-900/20"
       )}
     >
-      <div className="mt-0.5 shrink-0">{TYPE_ICON[type]}</div>
-
-      <div className="flex-1 space-y-0.5">
-        <div className="flex items-center justify-between gap-2">
-          <p
-            className={cn(
-              "text-sm font-medium",
-              read ? "text-muted-foreground" : "text-foreground",
-            )}
-          >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 shrink-0">{ICON_MAP[type]}</div>
+        <div className="flex-1 space-y-0.5">
+          <p className={cn("text-sm font-medium", read ? "text-gray-300" : "text-white")}>
             {title}
           </p>
-          {!read && (
-            <span className="h-2 w-2 rounded-full bg-purple-500 shrink-0" />
-          )}
+          <p className="text-xs text-gray-400">{message}</p>
+          <p className="text-xs text-gray-500">{timestamp}</p>
         </div>
-        <p className="text-xs text-muted-foreground">{message}</p>
-        <p className="text-xs text-muted-foreground">{timestamp}</p>
+        {!read && (
+          <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-purple-500" />
+        )}
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/components/dashboard/NotificationItem.tsx
+++ b/src/components/dashboard/NotificationItem.tsx
@@ -46,7 +46,7 @@ export function NotificationItem({
           <p className="text-xs text-gray-500">{timestamp}</p>
         </div>
         {!read && (
-          <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-purple-500" />
+          <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-purple-500" aria-label="Unread" />
         )}
       </div>
     </button>

--- a/src/components/layouts/SideBar.tsx
+++ b/src/components/layouts/SideBar.tsx
@@ -81,7 +81,7 @@ export function SideBar({
           </span>
         </Link>
         <Link
-          href="/notifications"
+          href="/dashboard/notifications"
           onClick={onClose}
           className="flex items-center gap-3 p-2 rounded-lg hover:bg-accent transition-colors duration-200 w-full relative group dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
         >


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

<!-- Briefly describe the purpose of the pull request. Explain the problem being solved or the functionality being implemented. -->
- Closes #391 

Homologates the notifications feature fix from `dApp-SafeTrust` (Issue #191 / PR #195) into `frontend-SafeTrust`. This resolves a 404 error when clicking the "Notifications" link in the sidebar by redirecting to a nested dashboard route and implementing the dedicated notifications page and item components.

## 🌀 Summary of Changes

<!-- List the main changes made in the code. Include new features, bug fixes, or refactored components. -->

* **SideBar Update**: Updated the Notifications navigation link target from the root `/notifications` to the nested `/dashboard/notifications` path.
* **Notifications Page**: Implemented the nested `/dashboard/notifications` client-side view featuring:
  * A mock list of success, info, and warning notifications.
  * State management for marking individual items or all items as read.
  * Empty state visualization when all notifications are cleared.
* **NotificationItem Component**: Created a reusable component for displaying notifications with specific icons, layouts, and style modifiers (distinguishing read and unread states).

## 🛠 Testing



<!-- Describe the behavior or issue before applying the solution. Use Loom to record a video showing the problem. Provide a link to the video. -->


### Evidence After Solution

<!-- Explain how the issue was fixed and demonstrate the corrected functionality. Use Loom to record another video showing the solution. Provide a link to the video. -->

- **Bell icon in Sidebar navigates to `/dashboard/notifications` (no longer 404)**
<img width="1919" height="970" alt="Screenshot 2026-07-08 231709" src="https://github.com/user-attachments/assets/e7aa0b9e-f40d-4dee-9cee-4f8e034ee914" />

- **"Mark as read" works**
<img width="1919" height="971" alt="Screenshot 2026-07-08 231745" src="https://github.com/user-attachments/assets/8f030467-98f6-40db-8e2d-cd780778ea52" />

- **"Mark all as read" works correctly**
<img width="1919" height="972" alt="Screenshot 2026-07-08 231903" src="https://github.com/user-attachments/assets/5a3a0276-7b7e-4e78-952c-4a1bfa707536" />

- **Empty state renders successfully when cleared**
<img width="1918" height="962" alt="Screenshot 2026-07-08 233211" src="https://github.com/user-attachments/assets/31d32084-e0a1-4412-9c54-5779e006112b" />


## 📂 Related Issue

<!-- Link the related issue so it automatically closes when this pull request is merged. -->

This pull request will **close #391** upon merging.

---

### Make sure to follow the Git Guidelines for Atomic Commits and read Contributing Guide

The Pull request needs to have the format mentioned below in the Git Guideline

- [Contributing Guide ](https://github.com/safetrustcr/Frontend/issues/34)
- [Git Guidelines](https://github.com/safetrustcr/Frontend/issues/35)

🎉 Thank you for reviewing this PR! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the notifications page styling for the “Mark all as read” action, divider, and empty state for a cleaner, more consistent look.
  * Updated notification items to behave as proper buttons, improving click interaction and accessibility.
  * Refined notification text, icon, and unread-state styling for better readability.
  * Fixed the sidebar Notifications link to open the correct dashboard notifications page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->