### PR TITLE
feature/escrow-detail-page

### DIFF
--- a/src/app/dashboard/escrow/[id]/page.tsx
+++ b/src/app/dashboard/escrow/[id]/page.tsx
@@ -38,14 +38,18 @@ export default async function EscrowDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const stub = getStubEscrow(id);
   const amount = 4000;
   const currency = "USDC";
+  const formattedAmount = formatEscrowAmount(amount, currency);
   const escrow = {
-    ...getStubEscrow(id),
+    ...stub,
     status: "FUNDED" as const,
     amount,
     currency,
-    total: formatEscrowAmount(amount, currency),
+    subtotal: formattedAmount,
+    discount: formatEscrowAmount(0, currency),
+    total: formattedAmount,
   };
 
   return (
@@ -70,7 +74,7 @@ export default async function EscrowDetailPage({
                 <div>
                   <p className="text-sm text-gray-400">Escrow amount</p>
                   <p className="text-2xl font-semibold text-gray-900 dark:text-white">
-                    {formatEscrowAmount(escrow.amount, escrow.currency)}
+                    {formattedAmount}
                   </p>
                 </div>
                 <div>
@@ -134,7 +138,7 @@ export default async function EscrowDetailPage({
               </div>
               <div className="flex justify-between text-sm text-gray-500 dark:text-slate-400">
                 <span>Amount billed</span>
-                <span>{escrow.total}</span>
+                <span>{formattedAmount}</span>
               </div>
               <div className="flex justify-between text-sm text-gray-500 dark:text-slate-400">
                 <span>Billing details</span>

--- a/src/app/dashboard/escrow/[id]/page.tsx
+++ b/src/app/dashboard/escrow/[id]/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { EscrowOverviewCard } from "@/components/escrow/EscrowOverviewCard";
+import { EscrowStatusBadge } from "@/components/dashboard/EscrowStatusBadge";
+import { InvoiceHeader } from "@/components/escrow/InvoiceHeader";
+import { ProcessStepper } from "@/components/escrow/ProcessStepper";
+import { EscrowPartyInfo } from "@/components/escrow/views/EscrowPartyInfo";
+import { MilestoneProgress } from "@/components/dashboard/milestone-progress";
+import { getStubEscrow } from "@/components/escrow/views/stubEscrow";
+import type { Milestone } from "@/components/dashboard/RoleEscrowDashboard";
+
+const milestoneData: Milestone[] = [
+  {
+    id: "check_in",
+    name: "check_in",
+    status: "completed",
+    dueDate: "2025-02-01",
+    completedAt: "2025-01-28",
+  },
+  {
+    id: "stay",
+    name: "stay",
+    status: "in_progress",
+    dueDate: "2025-02-10",
+  },
+  {
+    id: "check_out",
+    name: "check_out",
+    status: "pending",
+    dueDate: "2025-02-15",
+  },
+];
+
+export default function EscrowDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const escrow = {
+    ...getStubEscrow(params.id),
+    status: "FUNDED" as const,
+    amount: 4000,
+    currency: "USDC",
+  };
+
+  return (
+    <div className="space-y-6 max-w-6xl mx-auto">
+      <div className="flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors w-fit">
+        <Link href="/dashboard/escrow" className="flex items-center gap-2">
+          <ArrowLeft className="h-4 w-4" />
+          Back to My Escrows
+        </Link>
+      </div>
+
+      <InvoiceHeader invoiceNumber={escrow.invoiceNumber} status={escrow.status} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px] gap-6">
+        <div className="space-y-6">
+          <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm shadow-slate-100/50 dark:border-slate-700 dark:bg-slate-900">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-4">
+                <div>
+                  <p className="text-sm text-gray-400">Escrow amount</p>
+                  <p className="text-2xl font-semibold text-gray-900 dark:text-white">
+                    {escrow.amount.toLocaleString("en-US", {
+                      style: "currency",
+                      currency: escrow.currency,
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm text-gray-400">Escrow address</p>
+                  <p className="font-mono text-sm text-gray-900 dark:text-white break-all">
+                    {escrow.id}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm text-gray-400">Issued</p>
+                  <p className="text-sm text-gray-900 dark:text-white">{escrow.issued}</p>
+                </div>
+              </div>
+
+              <div className="flex flex-col justify-between rounded-3xl border border-gray-100 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-800">
+                <div>
+                  <p className="text-sm text-gray-400">Current Status</p>
+                  <EscrowStatusBadge status={escrow.status} />
+                </div>
+                <div className="mt-6">
+                  <p className="text-sm text-gray-400">Booking subject</p>
+                  <p className="text-sm text-gray-900 dark:text-white">{escrow.subject}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm shadow-slate-100/50 dark:border-slate-700 dark:bg-slate-900">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Process</h2>
+              <p className="text-sm text-gray-400 mb-4">
+                Timeline view of the escrow status and milestone progress.
+              </p>
+              <ProcessStepper currentStep={2} />
+            </div>
+
+            <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm shadow-slate-100/50 dark:border-slate-700 dark:bg-slate-900">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Milestone progress</h2>
+              <p className="text-sm text-gray-400 mb-4">
+                Review milestone completion, pending steps, and due dates.
+              </p>
+              <MilestoneProgress milestones={milestoneData} />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <EscrowPartyInfo variant="tenant" tenant={escrow.tenant} />
+            <EscrowPartyInfo variant="owner" owner={escrow.owner} />
+            <EscrowPartyInfo variant="beneficiary" beneficiary={escrow.beneficiary} />
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <EscrowOverviewCard />
+          <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm shadow-slate-100/50 dark:border-slate-700 dark:bg-slate-900">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Invoice details</h2>
+            <div className="mt-4 grid gap-3">
+              <div className="flex justify-between text-sm text-gray-500 dark:text-slate-400">
+                <span>Due date</span>
+                <span>{escrow.dueDate}</span>
+              </div>
+              <div className="flex justify-between text-sm text-gray-500 dark:text-slate-400">
+                <span>Amount billed</span>
+                <span>{escrow.total}</span>
+              </div>
+              <div className="flex justify-between text-sm text-gray-500 dark:text-slate-400">
+                <span>Billing details</span>
+                <span>{escrow.billingDetails}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/escrow/[id]/page.tsx
+++ b/src/app/dashboard/escrow/[id]/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { EscrowOverviewCard } from "@/components/escrow/EscrowOverviewCard";
@@ -33,13 +31,14 @@ const milestoneData: Milestone[] = [
   },
 ];
 
-export default function EscrowDetailPage({
+export default async function EscrowDetailPage({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
+  const { id } = await params;
   const escrow = {
-    ...getStubEscrow(params.id),
+    ...getStubEscrow(id),
     status: "FUNDED" as const,
     amount: 4000,
     currency: "USDC",
@@ -47,8 +46,11 @@ export default function EscrowDetailPage({
 
   return (
     <div className="space-y-6 max-w-6xl mx-auto">
-      <div className="flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors w-fit">
-        <Link href="/dashboard/escrow" className="flex items-center gap-2">
+      <div className="flex items-center gap-2 text-sm w-fit">
+        <Link
+          href="/dashboard/escrow"
+          className="flex items-center gap-2 text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+        >
           <ArrowLeft className="h-4 w-4" />
           Back to My Escrows
         </Link>

--- a/src/app/dashboard/escrow/[id]/page.tsx
+++ b/src/app/dashboard/escrow/[id]/page.tsx
@@ -7,6 +7,7 @@ import { ProcessStepper } from "@/components/escrow/ProcessStepper";
 import { EscrowPartyInfo } from "@/components/escrow/views/EscrowPartyInfo";
 import { MilestoneProgress } from "@/components/dashboard/milestone-progress";
 import { getStubEscrow } from "@/components/escrow/views/stubEscrow";
+import { formatEscrowAmount } from "@/lib/formatEscrowAmount";
 import type { Milestone } from "@/components/dashboard/RoleEscrowDashboard";
 
 const milestoneData: Milestone[] = [
@@ -37,11 +38,14 @@ export default async function EscrowDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const amount = 4000;
+  const currency = "USDC";
   const escrow = {
     ...getStubEscrow(id),
     status: "FUNDED" as const,
-    amount: 4000,
-    currency: "USDC",
+    amount,
+    currency,
+    total: formatEscrowAmount(amount, currency),
   };
 
   return (
@@ -66,12 +70,7 @@ export default async function EscrowDetailPage({
                 <div>
                   <p className="text-sm text-gray-400">Escrow amount</p>
                   <p className="text-2xl font-semibold text-gray-900 dark:text-white">
-                    {escrow.amount.toLocaleString("en-US", {
-                      style: "currency",
-                      currency: escrow.currency,
-                      minimumFractionDigits: 2,
-                      maximumFractionDigits: 2,
-                    })}
+                    {formatEscrowAmount(escrow.amount, escrow.currency)}
                   </p>
                 </div>
                 <div>

--- a/src/components/dashboard/EscrowTable.tsx
+++ b/src/components/dashboard/EscrowTable.tsx
@@ -49,7 +49,7 @@ export function EscrowTable({ escrows, userRole }: EscrowTableProps) {
   const router = useRouter();
 
   const handleViewDetails = (escrowId: string) => {
-    router.push(`/escrows/${escrowId}`);
+    router.push(`/dashboard/escrow/${escrowId}`);
   };
 
   const formatCurrency = (amount: number, currency: string) => {

--- a/tsconfig.temp.json
+++ b/tsconfig.temp.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/app/dashboard/escrow/[id]/page.tsx",
+    "src/components/dashboard/EscrowTable.tsx"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,29 +1718,17 @@
   resolved "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz"
   integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
 
-"@img/sharp-libvips-linux-x64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz"
-  integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
-
-"@img/sharp-libvips-linuxmusl-x64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz"
-  integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
-
-"@img/sharp-linux-x64@0.34.5":
+"@img/sharp-darwin-x64@0.34.5":
   version "0.34.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz"
-  integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
+  resolved "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz"
+  integrity sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==
   optionalDependencies:
-    "@img/sharp-libvips-linux-x64" "1.2.4"
+    "@img/sharp-libvips-darwin-x64" "1.2.4"
 
-"@img/sharp-linuxmusl-x64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz"
-  integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+"@img/sharp-libvips-darwin-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz"
+  integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
 
 "@inquirer/ansi@^1.0.2":
   version "1.0.2"
@@ -2393,15 +2381,10 @@
   dependencies:
     fast-glob "3.3.1"
 
-"@next/swc-linux-x64-gnu@15.5.15":
+"@next/swc-darwin-x64@15.5.15":
   version "15.5.15"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz"
-  integrity sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==
-
-"@next/swc-linux-x64-musl@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz"
-  integrity sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==
+  resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz"
+  integrity sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==
 
 "@ngneat/elf-devtools@1.3.0":
   version "1.3.0"
@@ -5412,15 +5395,10 @@
     "@typescript-eslint/types" "8.59.0"
     eslint-visitor-keys "^5.0.0"
 
-"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+"@unrs/resolver-binding-darwin-x64@1.11.1":
   version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz"
-  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
-
-"@unrs/resolver-binding-linux-x64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz"
-  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz"
+  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
 
 "@wallet-standard/base@^1.1.0":
   version "1.1.0"
@@ -9042,6 +9020,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Closes #408 

## Summary

Implements the escrow detail page at /dashboard/escrow/[id], resolving the dead "View" button on /dashboard/escrow.

## Changes

Modified — src/components/dashboard/EscrowTable.tsx
Wired the "View" button's onClick to navigate to /dashboard/escrow/${escrow.id} using useRouter from next/navigation.

Created — src/app/dashboard/escrow/[id]/page.tsx
New detail page reusing existing escrow components (no new components created):

InvoiceHeader — Booking ID and party info
EscrowOverviewCard + EscrowStatusBadge — amount, escrow address, current status
ProcessStepper — active step visualization
MilestoneProgress — milestone tracking
EscrowPartyInfo — involved parties
Uses stubEscrow for data shape, with a TODO marking the future Hasura query (public.trustless_work_escrows WHERE id = $id) per the issue's scope (stub data only, no backend wiring required for this issue)
"Back to My Escrows" link returns to /dashboard/escrow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an escrow detail dashboard page showing invoice header, escrow summary (amount, id, issued date), status badge, milestone progress, process stepper, party information, and invoice details.

- **Bug Fixes**
  - Updated “view details” navigation so escrow rows open the new dashboard route (`/dashboard/escrow/:escrowId`) instead of the prior path.

- **Chores**
  - Added a temporary TypeScript configuration scoped to the updated escrow dashboard and table components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->