### PR TITLE
feat: add Edit and Delete actions to Hotels table

### DIFF
--- a/src/app/dashboard/hotels/[id]/edit/page.tsx
+++ b/src/app/dashboard/hotels/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, MapPin, Building2, FileText } from "lucide-react";
@@ -57,6 +57,20 @@ export default function EditHotelPage() {
 
   const set = (field: keyof typeof form, value: string) =>
     setForm((prev) => ({ ...prev, [field]: value }));
+
+  useEffect(() => {
+    const next = STUB_HOTELS.find((h) => h.id === params.id);
+    if (next) {
+      setForm({
+        name: next.name,
+        description: next.description,
+        address: next.address,
+        location_area: next.location_area,
+        latitude: next.latitude,
+        longitude: next.longitude,
+      });
+    }
+  }, [params.id]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/app/dashboard/hotels/[id]/edit/page.tsx
+++ b/src/app/dashboard/hotels/[id]/edit/page.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, MapPin, Building2, FileText } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// TODO: replace with Hasura query → public.hotels WHERE id = $id
+// Stub data mirrors the list in src/app/dashboard/hotels/page.tsx
+const STUB_HOTELS = [
+  {
+    id: "1",
+    name: "Metropolitan Tower",
+    description: "Luxury hotel in downtown San José",
+    address: "Avenida Central 100, San José",
+    location_area: "San José Centro",
+    latitude: "9.9281",
+    longitude: "-84.0907",
+  },
+  {
+    id: "2",
+    name: "Mountain Peak Lodge",
+    description: "Boutique lodge with mountain views",
+    address: "Calle 5, Escazú, San José",
+    location_area: "Escazú",
+    latitude: "9.9200",
+    longitude: "-84.1400",
+  },
+  {
+    id: "3",
+    name: "Oceanview Resort & Spa",
+    description: "Beachfront resort with full spa",
+    address: "Playa Jacó, Puntarenas",
+    location_area: "Jacó",
+    latitude: "9.6100",
+    longitude: "-84.6300",
+  },
+];
+
+export default function EditHotelPage() {
+  const params = useParams();
+  const router = useRouter();
+  const hotel = STUB_HOTELS.find((h) => h.id === params.id);
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [form, setForm] = useState(
+    hotel ?? {
+      name: "",
+      description: "",
+      address: "",
+      location_area: "",
+      latitude: "9.9281",
+      longitude: "-84.0907",
+    },
+  );
+
+  const set = (field: keyof typeof form, value: string) =>
+    setForm((prev) => ({ ...prev, [field]: value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    // TODO: wire to Hasura mutation → UPDATE public.hotels SET ... WHERE id = $id
+    // Payload shape matches INSERT mutation from NewHotelPage:
+    // {
+    //   name: form.name,
+    //   description: form.description,
+    //   address: form.address,
+    //   location_area: form.location_area,
+    //   coordinates: `POINT(${form.longitude} ${form.latitude})`
+    // }
+
+    await new Promise((r) => setTimeout(r, 800));
+    setIsSubmitting(false);
+    router.push("/dashboard/hotels");
+  };
+
+  const inputClass = cn(
+    "w-full rounded-lg border border-gray-200 dark:border-slate-600",
+    "bg-white dark:bg-slate-900 px-4 py-2.5 text-sm",
+    "text-gray-900 dark:text-white",
+    "placeholder:text-gray-400 dark:placeholder:text-gray-500",
+    "focus:outline-none focus:ring-2 focus:ring-orange-500",
+    "transition-colors",
+  );
+
+  const labelClass =
+    "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1";
+
+  if (!hotel) {
+    return (
+      <div className="space-y-6 max-w-4xl mx-auto">
+        <Link
+          href="/dashboard/hotels"
+          className="flex items-center gap-2 text-sm
+                     text-gray-400 hover:text-white transition-colors w-fit"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Hotels
+        </Link>
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <Building2 className="h-12 w-12 text-gray-300 dark:text-gray-600 mb-4" />
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+            Hotel not found
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            The hotel you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <Link
+            href="/dashboard/hotels"
+            className="mt-6 rounded-lg bg-orange-500 hover:bg-orange-600
+                       text-white text-sm font-semibold px-4 py-2 transition-colors"
+          >
+            View all hotels
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-4xl mx-auto">
+
+      {/* Back */}
+      <Link
+        href="/dashboard/hotels"
+        className="flex items-center gap-2 text-sm
+                   text-gray-400 hover:text-white transition-colors w-fit"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to Hotels
+      </Link>
+
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          Edit Hotel
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Update details for hotel #{params.id}
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+
+          {/* ── Left column ── */}
+          <div className="space-y-4">
+
+            {/* Name */}
+            <div>
+              <label htmlFor="hotel-name" className={labelClass}>
+                Hotel Name <span className="text-red-500">*</span>
+              </label>
+              <div className="relative">
+                <Building2 className="absolute left-3 top-1/2 -translate-y-1/2
+                                      h-4 w-4 text-orange-400" />
+                <input
+                  id="hotel-name"
+                  type="text"
+                  required
+                  maxLength={20}
+                  placeholder="e.g. Metropolitan Tower"
+                  value={form.name}
+                  onChange={(e) => set("name", e.target.value)}
+                  className={cn(inputClass, "pl-9")}
+                />
+              </div>
+              <p className="text-xs text-gray-400 mt-1">
+                {form.name.length}/20 characters
+              </p>
+            </div>
+
+            {/* Address */}
+            <div>
+              <label htmlFor="hotel-address" className={labelClass}>
+                Address <span className="text-red-500">*</span>
+              </label>
+              <div className="relative">
+                <MapPin className="absolute left-3 top-1/2 -translate-y-1/2
+                                   h-4 w-4 text-orange-400" />
+                <input
+                  id="hotel-address"
+                  type="text"
+                  required
+                  maxLength={50}
+                  placeholder="e.g. Avenida Central 100, San José"
+                  value={form.address}
+                  onChange={(e) => set("address", e.target.value)}
+                  className={cn(inputClass, "pl-9")}
+                />
+              </div>
+            </div>
+
+            {/* Location area */}
+            <div>
+              <label htmlFor="hotel-location-area" className={labelClass}>Location Area</label>
+              <input
+                id="hotel-location-area"
+                type="text"
+                maxLength={20}
+                placeholder="e.g. San José Centro"
+                value={form.location_area}
+                onChange={(e) => set("location_area", e.target.value)}
+                className={inputClass}
+              />
+            </div>
+
+            {/* Coordinates */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="hotel-latitude" className={labelClass}>Latitude</label>
+                <input
+                  id="hotel-latitude"
+                  type="number"
+                  step="any"
+                  placeholder="9.9281"
+                  value={form.latitude}
+                  onChange={(e) => set("latitude", e.target.value)}
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label htmlFor="hotel-longitude" className={labelClass}>Longitude</label>
+                <input
+                  id="hotel-longitude"
+                  type="number"
+                  step="any"
+                  placeholder="-84.0907"
+                  value={form.longitude}
+                  onChange={(e) => set("longitude", e.target.value)}
+                  className={inputClass}
+                />
+              </div>
+            </div>
+            <p className="text-xs text-gray-400 -mt-2">
+              PostGIS coordinates — default is San José, Costa Rica center
+            </p>
+
+          </div>
+
+          {/* ── Right column ── */}
+          <div className="space-y-4">
+
+            {/* Description */}
+            <div>
+              <label htmlFor="hotel-description" className={labelClass}>
+                Description
+              </label>
+              <div className="relative">
+                <FileText className="absolute left-3 top-3
+                                     h-4 w-4 text-orange-400" />
+                <textarea
+                  id="hotel-description"
+                  maxLength={50}
+                  rows={5}
+                  placeholder="Describe the hotel — features, nearby amenities, special conditions..."
+                  value={form.description}
+                  onChange={(e) => set("description", e.target.value)}
+                  className={cn(inputClass, "pl-9 resize-none")}
+                />
+              </div>
+              <p className="text-xs text-gray-400 mt-1">
+                {form.description.length}/50 characters
+              </p>
+            </div>
+
+            {/* Schema note */}
+            <div className="rounded-lg border border-blue-200
+                            dark:border-blue-800 bg-blue-50
+                            dark:bg-blue-900/10 p-4 space-y-1">
+              <p className="text-xs font-semibold text-blue-600
+                             dark:text-blue-400">
+                Schema constraints (public.hotels)
+              </p>
+              <ul className="text-xs text-blue-500 dark:text-blue-400
+                              space-y-0.5 list-disc list-inside">
+                <li>name — max 20 characters, required</li>
+                <li>description — max 50 characters</li>
+                <li>address — max 50 characters, required</li>
+                <li>location_area — max 20 characters</li>
+                <li>coordinates — PostGIS Point (longitude, latitude)</li>
+              </ul>
+            </div>
+
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-end gap-3 pt-4
+                        border-t border-gray-200 dark:border-slate-700">
+          <Link
+            href="/dashboard/hotels"
+            className="px-6 py-2.5 rounded-lg border border-gray-200
+                       dark:border-slate-600 text-sm font-medium
+                       text-gray-600 dark:text-gray-300
+                       hover:bg-gray-50 dark:hover:bg-slate-800
+                       transition-colors"
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="px-6 py-2.5 rounded-lg bg-orange-500
+                       hover:bg-orange-600 active:bg-orange-700
+                       text-white text-sm font-semibold
+                       transition-colors disabled:opacity-60
+                       disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/dashboard/hotels/page.tsx
+++ b/src/app/dashboard/hotels/page.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
 import { PlusCircle } from "lucide-react";
+import { HotelActionsMenu } from "@/components/dashboard/hotels/HotelActionsMenu";
 
 // TODO: replace with Hasura query → public.hotels
 const STUB_HOTELS = [
@@ -27,6 +30,11 @@ const STUB_HOTELS = [
 ];
 
 export default function HotelsPage() {
+  const handleDeleteConfirmed = (id: string) => {
+    // TODO: trigger Hasura DELETE mutation → DELETE FROM public.hotels WHERE id = $id
+    console.warn(`Delete hotel ${id} — not yet wired to backend`);
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -91,13 +99,10 @@ export default function HotelsPage() {
                   {hotel.description}
                 </td>
                 <td className="px-4 py-3">
-                  <Link
-                    href={`/dashboard/hotels/${hotel.id}`}
-                    className="text-sm font-medium text-orange-500
-                               hover:text-orange-600 transition-colors"
-                  >
-                    View →
-                  </Link>
+                  <HotelActionsMenu
+                    hotelId={hotel.id}
+                    onDeleteConfirmed={handleDeleteConfirmed}
+                  />
                 </td>
               </tr>
             ))}

--- a/src/components/dashboard/hotels/HotelActionsMenu.tsx
+++ b/src/components/dashboard/hotels/HotelActionsMenu.tsx
@@ -31,7 +31,8 @@ export function HotelActionsMenu({ hotelId, onDeleteConfirmed }: HotelActionsMen
 
   const handleConfirmDelete = () => {
     // TODO: replace with Hasura DELETE mutation → DELETE FROM public.hotels WHERE id = $id
-    toast.success(`Hotel ${hotelId} deleted (stub)`);
+    // Once the mutation lands, replace with toast.success after a successful await
+    toast.info(`Delete requested for hotel #${hotelId} (stub — no backend wired)`);
     onDeleteConfirmed(hotelId);
     setDeleteOpen(false);
   };

--- a/src/components/dashboard/hotels/HotelActionsMenu.tsx
+++ b/src/components/dashboard/hotels/HotelActionsMenu.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface HotelActionsMenuProps {
+  hotelId: string;
+  onDeleteConfirmed: (id: string) => void;
+}
+
+export function HotelActionsMenu({ hotelId, onDeleteConfirmed }: HotelActionsMenuProps) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const handleConfirmDelete = () => {
+    // TODO: replace with Hasura DELETE mutation → DELETE FROM public.hotels WHERE id = $id
+    toast.success(`Hotel ${hotelId} deleted (stub)`);
+    onDeleteConfirmed(hotelId);
+    setDeleteOpen(false);
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="h-8 w-8 p-0" aria-label="Open hotel actions">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <Link href={`/dashboard/hotels/${hotelId}`}>
+              View →
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <Link href={`/dashboard/hotels/${hotelId}/edit`}>
+              <Pencil className="mr-2 h-4 w-4" />
+              Edit
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer text-destructive focus:text-destructive"
+            onSelect={() => setDeleteOpen(true)}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete hotel</DialogTitle>
+            <DialogDescription>
+              This action cannot be undone. This will permanently delete hotel #{hotelId}{" "}
+              from your listings.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button type="button" variant="outline" onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" onClick={handleConfirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds **Edit** and **Delete** actions to the Hotels table by replacing the existing static **"View →"** link with a reusable actions menu. It also introduces a pre-filled Hotel Edit page while preserving the current stub-based workflow and existing UI patterns.

The implementation follows the conventions used elsewhere in the project, particularly the existing `ApartmentActionsMenu`, to ensure a consistent user experience.

## Changes

### Added `HotelActionsMenu`

- Created a reusable `HotelActionsMenu` component for hotel row actions.
- Replaced the static **View** link with a dropdown menu.
- Added the following actions:
  - View
  - Edit
  - Delete
- Implemented delete confirmation using the existing shadcn `Dialog` pattern.
- Added `sonner` toast notifications consistent with the apartments module.
- Left a `TODO` placeholder for the future Hasura DELETE mutation.

### Added Hotel Edit Page

- Created `/dashboard/hotels/[id]/edit`.
- Added a pre-filled edit form using stub hotel data.
- Reused the layout, styling, and validation patterns from the existing New Hotel page.
- Added a loading state during form submission.
- Redirects back to the Hotels page after saving.
- Added a fallback for invalid hotel IDs.
- Left a `TODO` placeholder for the future Hasura UPDATE mutation.

### Updated Hotels Table

- Replaced the existing **"View →"** link with `HotelActionsMenu`.
- Added a temporary `handleDeleteConfirmed` callback with a `TODO` for backend integration.
- Preserved the existing table layout and stub data.

## Notes

- This PR intentionally keeps the current stub-based implementation intact.
- Backend CRUD operations are left as explicit `TODO`s until Hasura integration is available.
- No unrelated refactoring was introduced to keep the scope focused on the requested feature.

## Testing

- Verified the actions dropdown renders correctly for each hotel.
- Verified **View** navigates to the existing hotel details page.
- Verified **Edit** navigates to the new edit page.
- Verified the edit form is pre-filled with stub data.
- Verified the loading state is shown during save and redirects back to the Hotels list.
- Verified the delete confirmation dialog appears and triggers the temporary callback.
- Verified dark mode styling remains consistent.

Closes #420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hotel editing page with fields for name, description, address, area, and coordinates.
  * Added View, Edit, and Delete actions to hotel listings.
  * Added a confirmation dialog before deleting a hotel.
  * Added guidance for entering location coordinates and field limits.

* **Bug Fixes**
  * Added a clear message and return link when a requested hotel cannot be found.

* **Known Limitations**
  * Hotel deletion and editing currently display the interface but do not yet save changes permanently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->